### PR TITLE
feat(model); Added explicit readonly write protection in `TypeCollector`, replacing fatal reassignment failures with `InvalidArgumentException`, and expanded test coverage for readonly initialization and reassignment paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enh #2: Modernized the package API and documentation, including consistency improvements, structural cleanup, and migration guidance in `UPGRADE.md` (@terabytesoftw)
 - Enh #3: Unified `load()` with `setProperties()` to apply consistent snake_case to camelCase mapping, reduced timestamp initialization overhead during bulk loads, and updated related tests (@terabytesoftw)
+- Enh #4: Added explicit readonly write protection in `TypeCollector`, replacing fatal reassignment failures with `InvalidArgumentException`, and expanded test coverage for readonly initialization and reassignment paths (@terabytesoftw)
 
 ## 0.1.0 March 18, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -54,5 +54,6 @@ $model->load(['Profile' => ['publicEmailPersonal' => 'admin@example.com']]);
 $model->load(['Profile' => ['public_email_personal' => 'admin@example.com']]);
 
 // readonly reassignment now throws InvalidArgumentException
+$model->setPropertyValue('readonlyField', 'initial-value');
 $model->setPropertyValue('readonlyField', 'new-value');
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,6 +12,7 @@
 - `setProperties($data, $exceptProperties)` now matches exclusions using camelCase property names.
 - `getPropertyValue()` no longer mutates timestamp properties while reading.
 - `load()` now uses the same key normalization as `setProperties()`, mapping snake_case payload keys to camelCase model properties.
+- Assigning a value to an already initialized `readonly` property now throws `InvalidArgumentException` instead of surfacing a PHP fatal error.
 
 ### Migration steps
 
@@ -22,6 +23,7 @@
 - If your code asserts exact output from `getPropertyTypes()`, update expectations for nullable properties to include `'null'`.
 - Update `setProperties()` exclusions to camelCase names, e.g. `publicEmailPersonal` instead of `public_email_personal`.
 - Review `load()` payload keys if your models intentionally use underscored property names, because snake_case keys are now normalized to camelCase during assignment.
+- Handle `readonly` reassignment attempts as application-level exceptions when using `setPropertyValue()` or `setProperties()`.
 
 ```php
 <?php
@@ -50,4 +52,7 @@ $model->load(['Profile' => ['publicEmailPersonal' => 'admin@example.com']]);
 
 // snake_case now also works in load()
 $model->load(['Profile' => ['public_email_personal' => 'admin@example.com']]);
+
+// readonly reassignment now throws InvalidArgumentException
+$model->setPropertyValue('readonlyField', 'new-value');
 ```

--- a/src/Exception/Message.php
+++ b/src/Exception/Message.php
@@ -17,6 +17,13 @@ use function sprintf;
 enum Message: string
 {
     /**
+     * Indicates attempts to overwrite an initialized readonly property.
+     *
+     * Format: "Cannot overwrite initialized readonly property: '%s::%s'."
+     */
+    case READONLY_PROPERTY_ALREADY_INITIALIZED = "Cannot overwrite initialized readonly property: '%s::%s'.";
+
+    /**
      * Indicates an undefined property without model class context.
      *
      * Format: "Undefined property: '%s'."
@@ -29,13 +36,6 @@ enum Message: string
      * Format: "Undefined property: '%s::%s'."
      */
     case UNDEFINED_PROPERTY_WITH_CLASS = "Undefined property: '%s::%s'.";
-
-    /**
-     * Indicates attempts to overwrite an initialized readonly property.
-     *
-     * Format: "Cannot overwrite initialized readonly property: '%s::%s'."
-     */
-    case READONLY_PROPERTY_ALREADY_INITIALIZED = "Cannot overwrite initialized readonly property: '%s::%s'.";
 
     /**
      * Returns the formatted message string for the error case.

--- a/src/Exception/Message.php
+++ b/src/Exception/Message.php
@@ -31,6 +31,13 @@ enum Message: string
     case UNDEFINED_PROPERTY_WITH_CLASS = "Undefined property: '%s::%s'.";
 
     /**
+     * Indicates attempts to overwrite an initialized readonly property.
+     *
+     * Format: "Cannot overwrite initialized readonly property: '%s::%s'."
+     */
+    case READONLY_PROPERTY_ALREADY_INITIALIZED = "Cannot overwrite initialized readonly property: '%s::%s'.";
+
+    /**
      * Returns the formatted message string for the error case.
      *
      * Usage example:

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -618,7 +618,18 @@ final class TypeCollector
         if ($this->hasDeclaredProperty($property) === false) {
             $this->dynamicValues[$property] = $value;
         } else {
-            $this->reflection->getProperty($property)->setValue($this->model, $value);
+            $reflectionProperty = $this->reflection->getProperty($property);
+
+            if ($reflectionProperty->isReadOnly() && $reflectionProperty->isInitialized($this->model)) {
+                throw new InvalidArgumentException(
+                    Message::READONLY_PROPERTY_ALREADY_INITIALIZED->getMessage(
+                        $this->model::class,
+                        $property,
+                    ),
+                );
+            }
+
+            $reflectionProperty->setValue($this->model, $value);
         }
     }
 }

--- a/tests/Support/Model/ReadonlyState.php
+++ b/tests/Support/Model/ReadonlyState.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use UIAwesome\Model\AbstractModel;
+
+/**
+ * Stub model exposing readonly properties for assignment tests.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ReadonlyState extends AbstractModel
+{
+    public readonly string $token;
+
+    public function __construct(public readonly Country $country) {}
+}

--- a/tests/TypeCollectorTest.php
+++ b/tests/TypeCollectorTest.php
@@ -344,6 +344,23 @@ final class TypeCollectorTest extends TestCase
         $model->setPropertyValue('token', 'phase-2-update');
     }
 
+    public function testThrowInvalidArgumentExceptionWhenReassigningReadonlyPropertyViaSetProperties(): void
+    {
+        $model = new ReadonlyState(new Country());
+
+        $model->setProperties(['token' => 'phase-1']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::READONLY_PROPERTY_ALREADY_INITIALIZED->getMessage(
+                ReadonlyState::class,
+                'token',
+            ),
+        );
+
+        $model->setProperties(['token' => 'phase-2']);
+    }
+
     public function testThrowTypeErrorWhenAssigningInvalidPropertyValue(): void
     {
         $model = new PropertyType();

--- a/tests/TypeCollectorTest.php
+++ b/tests/TypeCollectorTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace UIAwesome\Model\Tests;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\TestCase;
 use TypeError;
+use UIAwesome\Model\Exception\Message;
 use UIAwesome\Model\Tests\Provider\TypeCollectorProvider;
-use UIAwesome\Model\Tests\Support\Model\{Address, Country, PropertyType};
+use UIAwesome\Model\Tests\Support\Model\{Address, Country, PropertyType, ReadonlyState};
 use UIAwesome\Model\TypeCollector;
 
 /**
@@ -295,6 +297,51 @@ final class TypeCollectorTest extends TestCase
             $model->getPropertyValue($property),
             'Should assign and return the expected value for each supported property input case.',
         );
+    }
+
+    public function testSetReadonlyPropertyWhenUninitialized(): void
+    {
+        $model = new ReadonlyState(new Country());
+
+        $model->setPropertyValue('token', 'phase-2');
+
+        self::assertSame(
+            'phase-2',
+            $model->getPropertyValue('token'),
+            'Should allow assigning an uninitialized readonly property once.',
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenOverwritingInitializedReadonlyProperty(): void
+    {
+        $model = new ReadonlyState(new Country());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::READONLY_PROPERTY_ALREADY_INITIALIZED->getMessage(
+                ReadonlyState::class,
+                'country',
+            ),
+        );
+
+        $model->setPropertyValue('country', new Country());
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenReassigningReadonlyPropertyAfterFirstInitialization(): void
+    {
+        $model = new ReadonlyState(new Country());
+
+        $model->setPropertyValue('token', 'phase-2');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::READONLY_PROPERTY_ALREADY_INITIALIZED->getMessage(
+                ReadonlyState::class,
+                'token',
+            ),
+        );
+
+        $model->setPropertyValue('token', 'phase-2-update');
     }
 
     public function testThrowTypeErrorWhenAssigningInvalidPropertyValue(): void


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
