### PR TITLE
feat(model): Extended automatic type casting to support `DateTime` and `DateTimeImmutable` from string input, added explicit invalid-date errors (including overflow-normalized dates), and expanded coverage for date casting paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enh #2: Modernized the package API and documentation, including consistency improvements, structural cleanup, and migration guidance in `UPGRADE.md` (@terabytesoftw)
 - Enh #3: Unified `load()` with `setProperties()` to apply consistent snake_case to camelCase mapping, reduced timestamp initialization overhead during bulk loads, and updated related tests (@terabytesoftw)
 - Enh #4: Added explicit readonly write protection in `TypeCollector`, replacing fatal reassignment failures with `InvalidArgumentException`, and expanded test coverage for readonly initialization and reassignment paths (@terabytesoftw)
+- Enh #5: Extended automatic type casting to support `DateTime` and `DateTimeImmutable` from string input, added explicit invalid-date errors, and expanded coverage for date casting paths (@terabytesoftw)
 
 ## 0.1.0 March 18, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Enh #2: Modernized the package API and documentation, including consistency improvements, structural cleanup, and migration guidance in `UPGRADE.md` (@terabytesoftw)
 - Enh #3: Unified `load()` with `setProperties()` to apply consistent snake_case to camelCase mapping, reduced timestamp initialization overhead during bulk loads, and updated related tests (@terabytesoftw)
 - Enh #4: Added explicit readonly write protection in `TypeCollector`, replacing fatal reassignment failures with `InvalidArgumentException`, and expanded test coverage for readonly initialization and reassignment paths (@terabytesoftw)
-- Enh #5: Extended automatic type casting to support `DateTime` and `DateTimeImmutable` from string input, added explicit invalid-date errors, and expanded coverage for date casting paths (@terabytesoftw)
+- Enh #5: Extended automatic type casting to support `DateTime` and `DateTimeImmutable` from string input, added explicit invalid-date errors (including overflow-normalized dates), and expanded coverage for date casting paths (@terabytesoftw)
 
 ## 0.1.0 March 18, 2024
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,8 @@
 - `getPropertyValue()` no longer mutates timestamp properties while reading.
 - `load()` now uses the same key normalization as `setProperties()`, mapping snake_case payload keys to camelCase model properties.
 - Assigning a value to an already initialized `readonly` property now throws `InvalidArgumentException` instead of surfacing a PHP fatal error.
+- Automatic type casting now supports `DateTime` and `DateTimeImmutable` when string values are assigned to properties declared with those types.
+- Invalid date/time strings now throw `InvalidArgumentException` with a clear casting error message.
 
 ### Migration steps
 
@@ -24,6 +26,7 @@
 - Update `setProperties()` exclusions to camelCase names, e.g. `publicEmailPersonal` instead of `public_email_personal`.
 - Review `load()` payload keys if your models intentionally use underscored property names, because snake_case keys are now normalized to camelCase during assignment.
 - Handle `readonly` reassignment attempts as application-level exceptions when using `setPropertyValue()` or `setProperties()`.
+- Validate incoming date strings before assignment if inputs are user-provided, because invalid values now fail fast with `InvalidArgumentException`.
 
 ```php
 <?php
@@ -56,4 +59,10 @@ $model->load(['Profile' => ['public_email_personal' => 'admin@example.com']]);
 // readonly reassignment now throws InvalidArgumentException
 $model->setPropertyValue('readonlyField', 'initial-value');
 $model->setPropertyValue('readonlyField', 'new-value');
+
+// DateTime and DateTimeImmutable now cast from strings
+$model->setPropertyValue('createdAt', '2026-02-28 10:30:00');
+
+// invalid date/time strings now throw InvalidArgumentException
+$model->setPropertyValue('createdAt', 'not-a-date');
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -15,6 +15,7 @@
 - Assigning a value to an already initialized `readonly` property now throws `InvalidArgumentException` instead of surfacing a PHP fatal error.
 - Automatic type casting now supports `DateTime` and `DateTimeImmutable` when string values are assigned to properties declared with those types.
 - Invalid date/time strings now throw `InvalidArgumentException` with a clear casting error message.
+- Overflow-normalized dates (for example `2026-02-30`) are now rejected as invalid instead of being silently normalized.
 
 ### Migration steps
 
@@ -27,6 +28,7 @@
 - Review `load()` payload keys if your models intentionally use underscored property names, because snake_case keys are now normalized to camelCase during assignment.
 - Handle `readonly` reassignment attempts as application-level exceptions when using `setPropertyValue()` or `setProperties()`.
 - Validate incoming date strings before assignment if inputs are user-provided, because invalid values now fail fast with `InvalidArgumentException`.
+- Update tests or input sanitization if your code previously relied on PHP date overflow normalization.
 
 ```php
 <?php

--- a/src/Exception/Message.php
+++ b/src/Exception/Message.php
@@ -24,6 +24,13 @@ enum Message: string
     case READONLY_PROPERTY_ALREADY_INITIALIZED = "Cannot overwrite initialized readonly property: '%s::%s'.";
 
     /**
+     * Indicates invalid string input for date/time object casting.
+     *
+     * Format: "Invalid date/time string '%s' for type '%s'."
+     */
+    case INVALID_DATE_TIME_STRING = "Invalid date/time string '%s' for type '%s'.";
+
+    /**
      * Indicates an undefined property without model class context.
      *
      * Format: "Undefined property: '%s'."

--- a/src/Exception/Message.php
+++ b/src/Exception/Message.php
@@ -17,18 +17,18 @@ use function sprintf;
 enum Message: string
 {
     /**
-     * Indicates attempts to overwrite an initialized readonly property.
-     *
-     * Format: "Cannot overwrite initialized readonly property: '%s::%s'."
-     */
-    case READONLY_PROPERTY_ALREADY_INITIALIZED = "Cannot overwrite initialized readonly property: '%s::%s'.";
-
-    /**
      * Indicates invalid string input for date/time object casting.
      *
      * Format: "Invalid date/time string '%s' for type '%s'."
      */
     case INVALID_DATE_TIME_STRING = "Invalid date/time string '%s' for type '%s'.";
+
+    /**
+     * Indicates attempts to overwrite an initialized readonly property.
+     *
+     * Format: "Cannot overwrite initialized readonly property: '%s::%s'."
+     */
+    case READONLY_PROPERTY_ALREADY_INITIALIZED = "Cannot overwrite initialized readonly property: '%s::%s'.";
 
     /**
      * Indicates an undefined property without model class context.

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -29,6 +29,7 @@ use function is_a;
 use function is_array;
 use function is_object;
 use function is_scalar;
+use function max;
 use function method_exists;
 use function str_contains;
 
@@ -344,10 +345,24 @@ final class TypeCollector
         }
 
         try {
-            return new $dateTimeClass($value);
-        } catch (Exception) {
+            $dateTime = new $dateTimeClass($value);
+            $errors = $dateTimeClass::getLastErrors();
+
+            if (is_array($errors)) {
+                $issueCount = max($errors['warning_count'], $errors['error_count']);
+
+                if ($issueCount > 0) {
+                    throw new InvalidArgumentException(
+                        Message::INVALID_DATE_TIME_STRING->getMessage($value, $dateTimeClass),
+                    );
+                }
+            }
+
+            return $dateTime;
+        } catch (Exception $exception) {
             throw new InvalidArgumentException(
                 Message::INVALID_DATE_TIME_STRING->getMessage($value, $dateTimeClass),
+                previous: $exception,
             );
         }
     }

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\Model;
 
+use DateTime;
+use DateTimeImmutable;
+use Exception;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionNamedType;
@@ -458,12 +461,35 @@ final class TypeCollector
     {
         return match ($expectedType) {
             'bool' => (bool) $value,
+            DateTime::class => $this->castDateTimeObject(DateTime::class, $value),
+            DateTimeImmutable::class => $this->castDateTimeObject(DateTimeImmutable::class, $value),
             'float' => is_numeric($value) ? (float) $value : $value,
             'int' => is_numeric($value) ? (int) $value : $value,
             'string' => is_scalar($value) || (is_object($value) && method_exists($value, '__toString'))
                 ? (string) $value : $value,
             default => $value,
         };
+    }
+
+    /**
+     * Casts string input to DateTime-compatible objects for declared date/time property types.
+     *
+     * @param class-string<DateTime>|class-string<DateTimeImmutable> $dateTimeClass
+     * @param mixed $value
+     */
+    private function castDateTimeObject(string $dateTimeClass, mixed $value): mixed
+    {
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        try {
+            return new $dateTimeClass($value);
+        } catch (Exception) {
+            throw new InvalidArgumentException(
+                Message::INVALID_DATE_TIME_STRING->getMessage($value, $dateTimeClass),
+            );
+        }
     }
 
     /**

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -333,6 +333,26 @@ final class TypeCollector
     }
 
     /**
+     * Casts string input to DateTime-compatible objects for declared date/time property types.
+     *
+     * @param class-string<DateTime>|class-string<DateTimeImmutable> $dateTimeClass
+     */
+    private function castDateTimeObject(string $dateTimeClass, mixed $value): mixed
+    {
+        if (!is_string($value)) {
+            return $value;
+        }
+
+        try {
+            return new $dateTimeClass($value);
+        } catch (Exception) {
+            throw new InvalidArgumentException(
+                Message::INVALID_DATE_TIME_STRING->getMessage($value, $dateTimeClass),
+            );
+        }
+    }
+
+    /**
      * Returns the list of property types indexed by property names.
      *
      * By default, this method returns all non-static properties of the class.
@@ -469,27 +489,6 @@ final class TypeCollector
                 ? (string) $value : $value,
             default => $value,
         };
-    }
-
-    /**
-     * Casts string input to DateTime-compatible objects for declared date/time property types.
-     *
-     * @param class-string<DateTime>|class-string<DateTimeImmutable> $dateTimeClass
-     * @param mixed $value
-     */
-    private function castDateTimeObject(string $dateTimeClass, mixed $value): mixed
-    {
-        if (!is_string($value)) {
-            return $value;
-        }
-
-        try {
-            return new $dateTimeClass($value);
-        } catch (Exception) {
-            throw new InvalidArgumentException(
-                Message::INVALID_DATE_TIME_STRING->getMessage($value, $dateTimeClass),
-            );
-        }
     }
 
     /**

--- a/tests/Support/Model/DateTimeType.php
+++ b/tests/Support/Model/DateTimeType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use DateTime;
+use DateTimeImmutable;
+use UIAwesome\Model\AbstractModel;
+
+/**
+ * Stub model declaring DateTime typed properties for tests.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class DateTimeType extends AbstractModel
+{
+    public DateTime $createdAt;
+    public DateTimeImmutable|null $publishedAt = null;
+    public DateTimeImmutable $updatedAt;
+}

--- a/tests/TypeCollectorTest.php
+++ b/tests/TypeCollectorTest.php
@@ -107,26 +107,6 @@ final class TypeCollectorTest extends TestCase
         );
     }
 
-    public function testCastStringToDateTimeProperty(): void
-    {
-        $model = new DateTimeType();
-
-        $model->setPropertyValue('createdAt', '2026-02-28 10:30:00');
-
-        $createdAt = $model->getPropertyValue('createdAt');
-
-        self::assertInstanceOf(
-            DateTime::class,
-            $createdAt,
-            'Should cast valid date strings to DateTime objects when the property type requires it.',
-        );
-        self::assertSame(
-            '2026-02-28 10:30:00',
-            $createdAt->format('Y-m-d H:i:s'),
-            'Should preserve the parsed timestamp value after DateTime casting.',
-        );
-    }
-
     public function testCastStringToDateTimeImmutableProperty(): void
     {
         $model = new DateTimeType();
@@ -148,30 +128,24 @@ final class TypeCollectorTest extends TestCase
         );
     }
 
-    public function testKeepDateTimeObjectInstanceWhenAlreadyTyped(): void
+    public function testCastStringToDateTimeProperty(): void
     {
         $model = new DateTimeType();
-        $dateTime = new DateTime('2026-02-28 14:00:00');
 
-        $model->setPropertyValue('createdAt', $dateTime);
+        $model->setPropertyValue('createdAt', '2026-02-28 10:30:00');
 
+        $createdAt = $model->getPropertyValue('createdAt');
+
+        self::assertInstanceOf(
+            DateTime::class,
+            $createdAt,
+            'Should cast valid date strings to DateTime objects when the property type requires it.',
+        );
         self::assertSame(
-            $dateTime,
-            $model->getPropertyValue('createdAt'),
-            'Should keep existing DateTime object instances without rebuilding them.',
+            '2026-02-28 10:30:00',
+            $createdAt->format('Y-m-d H:i:s'),
+            'Should preserve the parsed timestamp value after DateTime casting.',
         );
-    }
-
-    public function testThrowInvalidArgumentExceptionWhenCastingInvalidDateTimeString(): void
-    {
-        $model = new DateTimeType();
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            Message::INVALID_DATE_TIME_STRING->getMessage('not-a-date', DateTime::class),
-        );
-
-        $model->setPropertyValue('createdAt', 'not-a-date');
     }
 
     public function testCastValueToDeclaredPhpType(): void
@@ -190,6 +164,20 @@ final class TypeCollectorTest extends TestCase
             1.1,
             $model->getPropertyValue('float'),
             'Should cast numeric strings assigned to float properties.',
+        );
+    }
+
+    public function testKeepDateTimeObjectInstanceWhenAlreadyTyped(): void
+    {
+        $model = new DateTimeType();
+        $dateTime = new DateTime('2026-02-28 14:00:00');
+
+        $model->setPropertyValue('createdAt', $dateTime);
+
+        self::assertSame(
+            $dateTime,
+            $model->getPropertyValue('createdAt'),
+            'Should keep existing DateTime object instances without rebuilding them.',
         );
     }
 
@@ -379,6 +367,18 @@ final class TypeCollectorTest extends TestCase
             $model->getPropertyValue('token'),
             'Should allow assigning an uninitialized readonly property once.',
         );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenCastingInvalidDateTimeString(): void
+    {
+        $model = new DateTimeType();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::INVALID_DATE_TIME_STRING->getMessage('not-a-date', DateTime::class),
+        );
+
+        $model->setPropertyValue('createdAt', 'not-a-date');
     }
 
     public function testThrowInvalidArgumentExceptionWhenOverwritingInitializedReadonlyProperty(): void

--- a/tests/TypeCollectorTest.php
+++ b/tests/TypeCollectorTest.php
@@ -111,15 +111,26 @@ final class TypeCollectorTest extends TestCase
     {
         $model = new DateTimeType();
 
-        $model->setProperties([
-            'updatedAt' => '2026-02-28T10:30:00+00:00',
-            'publishedAt' => '2026-02-28T12:00:00+00:00',
-        ]);
-
+        $model->setProperties(
+            [
+                'updatedAt' => '2026-02-28T10:30:00+00:00',
+                'publishedAt' => '2026-02-28T12:00:00+00:00',
+            ],
+        );
+        self::assertSame(
+            '2026-02-28T10:30:00+00:00',
+            $model->getPropertyValue('updatedAt')->format('Y-m-d\TH:i:sP'),
+            'Should preserve updatedAt timestamp and timezone after casting.',
+        );
         self::assertInstanceOf(
             DateTimeImmutable::class,
             $model->getPropertyValue('updatedAt'),
             'Should cast ISO-8601 strings to DateTimeImmutable objects for typed properties.',
+        );
+        self::assertSame(
+            '2026-02-28T12:00:00+00:00',
+            $model->getPropertyValue('publishedAt')->format('Y-m-d\TH:i:sP'),
+            'Should preserve publishedAt timestamp and timezone after casting.',
         );
         self::assertInstanceOf(
             DateTimeImmutable::class,

--- a/tests/TypeCollectorTest.php
+++ b/tests/TypeCollectorTest.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace UIAwesome\Model\Tests;
 
+use DateTime;
+use DateTimeImmutable;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 use UIAwesome\Model\Exception\Message;
 use UIAwesome\Model\Tests\Provider\TypeCollectorProvider;
-use UIAwesome\Model\Tests\Support\Model\{Address, Country, PropertyType, ReadonlyState};
+use UIAwesome\Model\Tests\Support\Model\{Address, Country, DateTimeType, PropertyType, ReadonlyState};
 use UIAwesome\Model\TypeCollector;
 
 /**
@@ -103,6 +105,73 @@ final class TypeCollectorTest extends TestCase
             $model->getPropertyValue('string'),
             'Should cast stringable objects to string properties.',
         );
+    }
+
+    public function testCastStringToDateTimeProperty(): void
+    {
+        $model = new DateTimeType();
+
+        $model->setPropertyValue('createdAt', '2026-02-28 10:30:00');
+
+        $createdAt = $model->getPropertyValue('createdAt');
+
+        self::assertInstanceOf(
+            DateTime::class,
+            $createdAt,
+            'Should cast valid date strings to DateTime objects when the property type requires it.',
+        );
+        self::assertSame(
+            '2026-02-28 10:30:00',
+            $createdAt->format('Y-m-d H:i:s'),
+            'Should preserve the parsed timestamp value after DateTime casting.',
+        );
+    }
+
+    public function testCastStringToDateTimeImmutableProperty(): void
+    {
+        $model = new DateTimeType();
+
+        $model->setProperties([
+            'updatedAt' => '2026-02-28T10:30:00+00:00',
+            'publishedAt' => '2026-02-28T12:00:00+00:00',
+        ]);
+
+        self::assertInstanceOf(
+            DateTimeImmutable::class,
+            $model->getPropertyValue('updatedAt'),
+            'Should cast ISO-8601 strings to DateTimeImmutable objects for typed properties.',
+        );
+        self::assertInstanceOf(
+            DateTimeImmutable::class,
+            $model->getPropertyValue('publishedAt'),
+            'Should cast nullable DateTimeImmutable properties when non-null strings are provided.',
+        );
+    }
+
+    public function testKeepDateTimeObjectInstanceWhenAlreadyTyped(): void
+    {
+        $model = new DateTimeType();
+        $dateTime = new DateTime('2026-02-28 14:00:00');
+
+        $model->setPropertyValue('createdAt', $dateTime);
+
+        self::assertSame(
+            $dateTime,
+            $model->getPropertyValue('createdAt'),
+            'Should keep existing DateTime object instances without rebuilding them.',
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenCastingInvalidDateTimeString(): void
+    {
+        $model = new DateTimeType();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::INVALID_DATE_TIME_STRING->getMessage('not-a-date', DateTime::class),
+        );
+
+        $model->setPropertyValue('createdAt', 'not-a-date');
     }
 
     public function testCastValueToDeclaredPhpType(): void

--- a/tests/TypeCollectorTest.php
+++ b/tests/TypeCollectorTest.php
@@ -369,7 +369,7 @@ final class TypeCollectorTest extends TestCase
         );
     }
 
-    public function testThrowInvalidArgumentExceptionWhenCastingInvalidDateTimeString(): void
+    public function testThrowInvalidArgumentExceptionWhenCastingDateTimeString(): void
     {
         $model = new DateTimeType();
 
@@ -379,6 +379,18 @@ final class TypeCollectorTest extends TestCase
         );
 
         $model->setPropertyValue('createdAt', 'not-a-date');
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenCastingOverflowDateTimeString(): void
+    {
+        $model = new DateTimeType();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::INVALID_DATE_TIME_STRING->getMessage('2026-02-30 10:30:00', DateTime::class),
+        );
+
+        $model->setPropertyValue('createdAt', '2026-02-30 10:30:00');
     }
 
     public function testThrowInvalidArgumentExceptionWhenOverwritingInitializedReadonlyProperty(): void


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
