### PR TITLE
feat(attribute): Added `#[MapFrom('key')]` for explicit payload-key mapping in `setProperties()` and `load()`, including support for non-snake_case keys and validation for duplicate mappings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enh #3: Unified `load()` with `setProperties()` to apply consistent snake_case to camelCase mapping, reduced timestamp initialization overhead during bulk loads, and updated related tests (@terabytesoftw)
 - Enh #4: Added explicit readonly write protection in `TypeCollector`, replacing fatal reassignment failures with `InvalidArgumentException`, and expanded test coverage for readonly initialization and reassignment paths (@terabytesoftw)
 - Enh #5: Extended automatic type casting to support `DateTime` and `DateTimeImmutable` from string input, added explicit invalid-date errors (including overflow-normalized dates), and expanded coverage for date casting paths (@terabytesoftw)
+- Enh #6: Added `#[MapFrom('key')]` for explicit payload-key mapping in `setProperties()` and `load()`, including support for non-snake_case keys and validation for duplicate mappings (@terabytesoftw)
 
 ## 0.1.0 March 18, 2024
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <p align="center">
     <strong>Typed model mapping for modern PHP applications</strong><br>
-    <em>Nested properties, controlled casting, timestamp attributes, and array serialization</em>
+    <em>Nested properties, explicit input mapping, controlled casting, and array serialization</em>
 </p>
 
 ## Features
@@ -48,11 +48,12 @@ declare(strict_types=1);
 namespace App\Model;
 
 use UIAwesome\Model\AbstractModel;
-use UIAwesome\Model\Attribute\Timestamp;
+use UIAwesome\Model\Attribute\{MapFrom, Timestamp};
 
 final class User extends AbstractModel
 {
     public string $name = '';
+    #[MapFrom('user-email-address')]
     public string $email = '';
     #[Timestamp]
     private int $updatedAt = 0;
@@ -64,7 +65,7 @@ $model->load(
     [
         'User' => [
             'name' => 'Ada Lovelace',
-            'email' => 'ada@example.com',
+            'user-email-address' => 'ada@example.com',
         ],
     ],
 );
@@ -72,6 +73,30 @@ $model->load(
 $model->setPropertyValue('name', 'Ada');
 $types = $model->getPropertyTypes();
 $payload = $model->toArray(snakeCase: true, exceptProperties: ['updatedAt']);
+```
+
+## Explicit payload mapping with `MapFrom`
+
+Use `#[MapFrom('external-key')]` when incoming payload keys do not follow snake_case or camelCase naming.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\MapFrom;
+
+final class JsonLdPayload extends AbstractModel
+{
+    #[MapFrom('@context')]
+    public string $context = '';
+}
+
+$payload = new JsonLdPayload();
+$payload->setProperties(['@context' => 'https://schema.org']);
 ```
 
 ## Documentation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,11 +16,12 @@ declare(strict_types=1);
 namespace App\Model;
 
 use UIAwesome\Model\AbstractModel;
-use UIAwesome\Model\Attribute\{DoNotCollect, Timestamp};
+use UIAwesome\Model\Attribute\{DoNotCollect, MapFrom, Timestamp};
 
 final class User extends AbstractModel
 {
     public string $name = '';
+    #[MapFrom('user-email-address')]
     public string $email = '';
     #[DoNotCollect]
     private string $internalToken = '';
@@ -33,15 +34,18 @@ final class User extends AbstractModel
 
 - `load(iterable $data, ?string $modelName = null)` accepts scoped and unscoped payloads.
 - Input keys must match existing properties; undefined keys throw `InvalidArgumentException`.
+- `load()` and `setProperties()` both support explicit input mapping via `#[MapFrom('external-key')]`.
 - `isEmpty()` indicates whether loaded raw data is empty.
 
 ```php
-$model->load([
-    'User' => [
-        'name' => 'Ada Lovelace',
-        'email' => 'ada@example.com',
+$model->load(
+    [
+        'User' => [
+            'name' => 'Ada Lovelace',
+            'user-email-address' => 'ada@example.com',
+        ],
     ],
-]);
+);
 ```
 
 ## Type metadata
@@ -58,12 +62,21 @@ $types = $model->getPropertyTypes();
 
 - `setPropertyValue()` assigns a single property and supports nested paths (`profile.address.city`).
 - `setProperties()` assigns multiple values and converts snake_case input keys to camelCase.
+- `#[MapFrom('key')]` has priority over snake_case conversion for matching input payload keys.
 - `setProperties($data, $exceptProperties)` exclusions are evaluated in camelCase.
 
 ```php
-$model->setProperties([
-    'public_email_personal' => 'dev@example.com',
-], ['publicEmailPersonal']);
+$model->setProperties(['public_email_personal' => 'dev@example.com'], ['publicEmailPersonal']);
+$model->setProperties(['user-email-address' => 'dev@example.com']);
+```
+
+## Date object casting
+
+- `DateTime` and `DateTimeImmutable` typed properties are cast automatically from string values.
+- Invalid date strings and overflow-normalized dates (for example `2026-02-30`) throw `InvalidArgumentException`.
+
+```php
+$model->setPropertyValue('publishedAt', '2026-03-01T10:00:00+00:00');
 ```
 
 ## Array serialization

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,18 +12,44 @@ declare(strict_types=1);
 namespace App\Model;
 
 use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\MapFrom;
 
 final class User extends AbstractModel
 {
     public string $name = '';
+    #[MapFrom('user-age')]
     public int $age = 0;
 }
 
 $model = new User();
-$model->load(['User' => ['name' => 'Jane', 'age' => 20]]);
 
+$model->load(['User' => ['name' => 'Jane', 'user-age' => 20]]);
 echo $model->getPropertyValue('name');
 echo $model->getPropertyValue('age');
+```
+
+## Explicit payload-key mapping
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\MapFrom;
+
+final class JsonLdContext extends AbstractModel
+{
+    #[MapFrom('@context')]
+    public string $context = '';
+}
+
+$model = new JsonLdContext();
+
+$model->setProperties(['@context' => 'https://schema.org']);
+echo $model->getPropertyValue('context');
 ```
 
 ## Nested model access
@@ -49,8 +75,8 @@ final class Profile extends AbstractModel
 }
 
 $profile = new Profile(new Address());
-$profile->setPropertyValue('address.city', 'Madrid');
 
+$profile->setPropertyValue('address.city', 'Madrid');
 echo $profile->getPropertyValue('address.city');
 ```
 
@@ -73,11 +99,13 @@ $model->addProperty('name', 'string');
 $model->addProperty('age', 'int');
 $model->addProperty('createdAt', 'timestamp');
 
-$model->load([
-    'name' => 'John Doe',
-    'age' => 30,
-], 'DynamicModel');
-
+$model->load(
+    [
+        'name' => 'John Doe',
+        'age' => 30,
+    ], 
+    'DynamicModel',
+);
 echo $model->getPropertyValue('name');
 echo $model->getPropertyValue('createdAt');
 ```
@@ -86,6 +114,29 @@ echo $model->getPropertyValue('createdAt');
 
 ```php
 $array = $model->toArray(snakeCase: true, exceptProperties: ['createdAt']);
+```
+
+## DateTime casting
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use DateTimeImmutable;
+use UIAwesome\Model\AbstractModel;
+
+final class Post extends AbstractModel
+{
+    public DateTimeImmutable $publishedAt;
+}
+
+$model = new Post();
+
+$model->setPropertyValue('publishedAt', '2026-03-01T10:00:00+00:00');
+echo $model->getPropertyValue('publishedAt')->format(DATE_ATOM);
 ```
 
 ## Next steps

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -103,7 +103,7 @@ $model->load(
     [
         'name' => 'John Doe',
         'age' => 30,
-    ], 
+    ],
     'DynamicModel',
 );
 echo $model->getPropertyValue('name');

--- a/docs/svgs/features-mobile.svg
+++ b/docs/svgs/features-mobile.svg
@@ -1,4 +1,4 @@
-<svg fill="none" viewBox="0 0 600 560" width="100%" height="560" xmlns="http://www.w3.org/2000/svg">
+<svg fill="none" viewBox="0 0 600 580" width="100%" height="560" xmlns="http://www.w3.org/2000/svg">
     <foreignObject width="100%" height="100%">
         <div xmlns="http://www.w3.org/1999/xhtml">
             <style>
@@ -48,7 +48,7 @@
                 </div>
                 <div class="card">
                     <p class="title"><strong>Attribute Controls</strong></p>
-                    <p class="content"><code>#[DoNotCollect]</code> excludes fields and <code>#[Timestamp]</code> initializes timestamps safely.</p>
+                    <p class="content"><code>#[MapFrom]</code> maps external payload keys while <code>#[DoNotCollect]</code> and <code>#[Timestamp]</code> control collection and timestamps.</p>
                 </div>
                 <div class="card">
                     <p class="title"><strong>Model Loading</strong></p>
@@ -64,7 +64,7 @@
                 </div>
                 <div class="card">
                     <p class="title"><strong>Typed Properties</strong></p>
-                    <p class="content">Reflection-based type collection with scalar conversion for predictable model assignment.</p>
+                    <p class="content">Reflection-based type collection with scalar and DateTime casting plus safe readonly write protection.</p>
                 </div>
             </div>
         </div>

--- a/docs/svgs/features.svg
+++ b/docs/svgs/features.svg
@@ -46,7 +46,7 @@
                 </div>
                 <div class="card">
                     <p class="title"><strong>Attribute Controls</strong></p>
-                    <p class="content"><code>#[DoNotCollect]</code> excludes fields and <code>#[Timestamp]</code> initializes timestamps safely.</p>
+                    <p class="content"><code>#[MapFrom]</code> maps external payload keys while <code>#[DoNotCollect]</code> and <code>#[Timestamp]</code> control collection and timestamps.</p>
                 </div>
                 <div class="card">
                     <p class="title"><strong>Model Loading</strong></p>
@@ -62,7 +62,7 @@
                 </div>
                 <div class="card">
                     <p class="title"><strong>Typed Properties</strong></p>
-                    <p class="content">Reflection-based type collection with scalar conversion for predictable model assignment.</p>
+                    <p class="content">Reflection-based type collection with scalar and DateTime casting plus safe readonly write protection.</p>
                 </div>
             </div>
         </div>

--- a/src/Attribute/MapFrom.php
+++ b/src/Attribute/MapFrom.php
@@ -8,6 +8,8 @@ use Attribute;
 use InvalidArgumentException;
 use UIAwesome\Model\Exception\Message;
 
+use function trim;
+
 /**
  * Maps a model property from an explicit input key.
  *
@@ -24,7 +26,7 @@ final class MapFrom
 
     public function __construct(string $key)
     {
-        if ($key === '') {
+        if (trim($key) === '') {
             throw new InvalidArgumentException(
                 Message::MAP_FROM_KEY_EMPTY->getMessage(),
             );

--- a/src/Attribute/MapFrom.php
+++ b/src/Attribute/MapFrom.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Attribute;
+
+use Attribute;
+use InvalidArgumentException;
+use UIAwesome\Model\Exception\Message;
+
+/**
+ * Maps a model property from an explicit input key.
+ *
+ * Usage example:
+ * ```php
+ * #[MapFrom('user-email-address')]
+ * public string $publicEmail = '';
+ * ```
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class MapFrom
+{
+    public readonly string $key;
+
+    public function __construct(string $key)
+    {
+        if ($key === '') {
+            throw new InvalidArgumentException(
+                Message::MAP_FROM_KEY_EMPTY->getMessage(),
+            );
+        }
+
+        $this->key = $key;
+    }
+}

--- a/src/Exception/Message.php
+++ b/src/Exception/Message.php
@@ -17,11 +17,24 @@ use function sprintf;
 enum Message: string
 {
     /**
+     * Indicates duplicate input-key mapping across model properties.
+     *
+     * Format: "Duplicate MapFrom key '%s' in '%s::%s' and '%s::%s'."
+     */
+    case DUPLICATE_MAP_FROM_KEY = "Duplicate MapFrom key '%s' in '%s::%s' and '%s::%s'.";
+    /**
      * Indicates invalid string input for date/time object casting.
      *
      * Format: "Invalid date/time string '%s' for type '%s'."
      */
     case INVALID_DATE_TIME_STRING = "Invalid date/time string '%s' for type '%s'.";
+
+    /**
+     * Indicates an empty MapFrom input key.
+     *
+     * Format: "MapFrom key cannot be empty."
+     */
+    case MAP_FROM_KEY_EMPTY = 'MapFrom key cannot be empty.';
 
     /**
      * Indicates attempts to overwrite an initialized readonly property.

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -12,7 +12,7 @@ use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionProperty;
 use ReflectionUnionType;
-use UIAwesome\Model\Attribute\{DoNotCollect, Timestamp};
+use UIAwesome\Model\Attribute\{DoNotCollect, MapFrom, Timestamp};
 use UIAwesome\Model\Exception\Message;
 
 use function array_filter;
@@ -50,6 +50,11 @@ final class TypeCollector
     private array $dynamicValues = [];
 
     /**
+     * @phpstan-var array<string, string>
+     */
+    private array $mapFromKeys = [];
+
+    /**
      * @phpstan-var array<string, list<string>|string>
      */
     private array $properties = [];
@@ -63,6 +68,7 @@ final class TypeCollector
     {
         $this->reflection = new ReflectionClass($this->model);
         $this->properties = $this->collectProperties();
+        $this->mapFromKeys = $this->collectMapFromKeys();
     }
 
     /**
@@ -247,7 +253,7 @@ final class TypeCollector
 
         foreach ($data as $property => $value) {
             if (is_string($property)) {
-                $camelCaseName = $this->snakeCaseToCamelCase($property);
+                $camelCaseName = $this->resolveInputPropertyName($property);
 
                 if (in_array($camelCaseName, $exceptProperties, true)) {
                     continue;
@@ -302,6 +308,7 @@ final class TypeCollector
     {
         /** @var list<string> $properties */
         $properties = array_keys($this->getPropertyTypes());
+
         $result = [];
 
         foreach ($properties as $property) {
@@ -346,6 +353,7 @@ final class TypeCollector
 
         try {
             $dateTime = new $dateTimeClass($value);
+
             $errors = $dateTimeClass::getLastErrors();
 
             if (is_array($errors)) {
@@ -365,6 +373,45 @@ final class TypeCollector
                 previous: $exception,
             );
         }
+    }
+
+    /**
+     * Collects explicit input-key mappings from `MapFrom` property attributes.
+     *
+     * @return array<string, string>
+     */
+    private function collectMapFromKeys(): array
+    {
+        $keys = [];
+
+        foreach ($this->reflection->getProperties() as $property) {
+            if ($property->isStatic() || $this->hasDoNotCollectAttribute($property)) {
+                continue;
+            }
+
+            foreach ($property->getAttributes(MapFrom::class) as $attribute) {
+                /** @var MapFrom $mapFrom */
+                $mapFrom = $attribute->newInstance();
+
+                $key = $mapFrom->key;
+
+                if (array_key_exists($key, $keys) && $keys[$key] !== $property->getName()) {
+                    throw new InvalidArgumentException(
+                        Message::DUPLICATE_MAP_FROM_KEY->getMessage(
+                            $key,
+                            $this->model::class,
+                            $keys[$key],
+                            $this->model::class,
+                            $property->getName(),
+                        ),
+                    );
+                }
+
+                $keys[$key] = $property->getName();
+            }
+        }
+
+        return $keys;
     }
 
     /**
@@ -534,6 +581,18 @@ final class TypeCollector
     }
 
     /**
+     * Resolves an input key to the model property name.
+     */
+    private function resolveInputPropertyName(string $property): string
+    {
+        if (array_key_exists($property, $this->mapFromKeys)) {
+            return $this->mapFromKeys[$property];
+        }
+
+        return $this->snakeCaseToCamelCase($property);
+    }
+
+    /**
      * Resolves the type to be used for casting when multiple types are defined for a property.
      *
      * This method takes an array of expected types and returns the type to be used for casting.
@@ -592,6 +651,7 @@ final class TypeCollector
 
         /** @var int<0, max> $lastPropertyKey */
         $lastPropertyKey = array_key_last($properties);
+
         $lastProperty = $properties[$lastPropertyKey];
 
         $nestedProperty = array_slice($properties, 0, $propertyCount - 1);
@@ -612,6 +672,7 @@ final class TypeCollector
     private function snakeCaseToCamelCase(string $snakeCaseString): string
     {
         $words = explode('_', $snakeCaseString);
+
         $camelCase = '';
 
         foreach ($words as $index => $word) {

--- a/tests/Attribute/MapFromAttributeTest.php
+++ b/tests/Attribute/MapFromAttributeTest.php
@@ -2,13 +2,12 @@
 
 declare(strict_types=1);
 
-namespace UIAwesome\Model\Tests;
+namespace UIAwesome\Model\Tests\Attribute;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use UIAwesome\Model\AbstractModel;
-use UIAwesome\Model\Attribute\DoNotCollect;
-use UIAwesome\Model\Attribute\MapFrom;
+use UIAwesome\Model\Attribute\{DoNotCollect, MapFrom};
 use UIAwesome\Model\Exception\Message;
 use UIAwesome\Model\Tests\Support\Model\{MapFromDuplicate, MapFromPayload};
 
@@ -173,6 +172,21 @@ final class MapFromAttributeTest extends TestCase
     {
         $model = new class extends AbstractModel {
             #[MapFrom('')]
+            public string $name = '';
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::MAP_FROM_KEY_EMPTY->getMessage(),
+        );
+
+        $model->setProperties(['name' => 'Ada']);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenMapFromKeyIsWhitespaceOnly(): void
+    {
+        $model = new class extends AbstractModel {
+            #[MapFrom('   ')]
             public string $name = '';
         };
 

--- a/tests/MapFromAttributeTest.php
+++ b/tests/MapFromAttributeTest.php
@@ -65,6 +65,7 @@ final class MapFromAttributeTest extends TestCase
             'Should ignore MapFrom metadata on DoNotCollect properties when resolving keys.',
         );
     }
+
     public function testLoadWithMapFromKeysAndSnakeCaseFallback(): void
     {
         $model = new MapFromPayload();

--- a/tests/MapFromAttributeTest.php
+++ b/tests/MapFromAttributeTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\DoNotCollect;
+use UIAwesome\Model\Attribute\MapFrom;
+use UIAwesome\Model\Exception\Message;
+use UIAwesome\Model\Tests\Support\Model\{MapFromDuplicate, MapFromPayload};
+
+/**
+ * Unit tests for explicit input-key mapping with {@see \UIAwesome\Model\Attribute\MapFrom}.
+ *
+ * Test coverage.
+ * - Applies mapping consistently across `setProperties()` and `load()`.
+ * - Keeps `exceptProperties` behavior based on resolved camelCase property names.
+ * - Maps non-snake_case payload keys to model properties via `MapFrom`.
+ * - Preserves snake_case to camelCase fallback for properties without `MapFrom`.
+ * - Throws explicit errors for duplicate `MapFrom` key declarations.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class MapFromAttributeTest extends TestCase
+{
+    public function testCollectMappedKeysAfterDoNotCollectPropertyDeclaration(): void
+    {
+        $model = new class extends AbstractModel {
+            #[DoNotCollect]
+            public string $ignored = '';
+
+            #[MapFrom('external-key')]
+            public string $name = '';
+        };
+
+        $model->setProperties(['external-key' => 'Lin']);
+
+        self::assertSame(
+            'Lin',
+            $model->getPropertyValue('name'),
+            'Should continue scanning properties after DoNotCollect entries to gather later MapFrom keys.',
+        );
+    }
+
+    public function testIgnoreMapFromDeclaredOnDoNotCollectPropertyWhenCheckingDuplicates(): void
+    {
+        $model = new class extends AbstractModel {
+            #[DoNotCollect]
+            #[MapFrom('same-key')]
+            public string $ignored = '';
+
+            #[MapFrom('same-key')]
+            public string $name = '';
+        };
+
+        $model->setProperties(['same-key' => 'Ada']);
+
+        self::assertSame(
+            'Ada',
+            $model->getPropertyValue('name'),
+            'Should ignore MapFrom metadata on DoNotCollect properties when resolving keys.',
+        );
+    }
+    public function testLoadWithMapFromKeysAndSnakeCaseFallback(): void
+    {
+        $model = new MapFromPayload();
+
+        self::assertTrue(
+            $model->load(
+                [
+                    'MapFromPayload' => [
+                        '@context' => 'https://schema.org',
+                        'user-email-address' => 'admin@example.com',
+                        'public_email_personal' => 'public@example.com',
+                    ],
+                ],
+            ),
+            'Should load values from explicit MapFrom keys and snake_case fallback keys.',
+        );
+        self::assertSame(
+            'https://schema.org',
+            $model->getPropertyValue('context'),
+            'Should map @context payload key to the context property.',
+        );
+        self::assertSame(
+            'admin@example.com',
+            $model->getPropertyValue('userEmailAddress'),
+            'Should map non-snake_case payload key to property through MapFrom.',
+        );
+        self::assertSame(
+            'public@example.com',
+            $model->getPropertyValue('publicEmailPersonal'),
+            'Should keep snake_case to camelCase fallback for properties without MapFrom.',
+        );
+    }
+
+    public function testSetPropertiesAllowsDirectPropertyNameOnMappedField(): void
+    {
+        $model = new MapFromPayload();
+
+        $model->setProperties(['userEmailAddress' => 'direct@example.com']);
+
+        self::assertSame(
+            'direct@example.com',
+            $model->getPropertyValue('userEmailAddress'),
+            'Should still allow direct camelCase assignment for mapped properties.',
+        );
+    }
+
+    public function testSetPropertiesWithMapFromKeys(): void
+    {
+        $model = new MapFromPayload();
+
+        $model->setProperties(
+            [
+                '@context' => 'https://example.com/context',
+                'user-email-address' => 'hello@example.com',
+            ],
+        );
+
+        self::assertSame(
+            'https://example.com/context',
+            $model->getPropertyValue('context'),
+            'Should resolve explicit input key mapping in setProperties.',
+        );
+        self::assertSame(
+            'hello@example.com',
+            $model->getPropertyValue('userEmailAddress'),
+            'Should assign mapped values for explicit input keys in setProperties.',
+        );
+    }
+
+    public function testSkipMappedPropertyWhenExcludedByCamelCaseName(): void
+    {
+        $model = new MapFromPayload();
+
+        $model->setProperties(
+            ['user-email-address' => 'admin@example.com'],
+            ['userEmailAddress'],
+        );
+
+        self::assertSame(
+            '',
+            $model->getPropertyValue('userEmailAddress'),
+            'Should skip mapped assignments when the resolved property is in exceptProperties.',
+        );
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenMapFromKeyIsDuplicated(): void
+    {
+        $model = new MapFromDuplicate();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::DUPLICATE_MAP_FROM_KEY->getMessage(
+                'duplicate-key',
+                MapFromDuplicate::class,
+                'first',
+                MapFromDuplicate::class,
+                'second',
+            ),
+        );
+
+        $model->setProperties(['duplicate-key' => 'value']);
+    }
+
+    public function testThrowInvalidArgumentExceptionWhenMapFromKeyIsEmpty(): void
+    {
+        $model = new class extends AbstractModel {
+            #[MapFrom('')]
+            public string $name = '';
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::MAP_FROM_KEY_EMPTY->getMessage(),
+        );
+
+        $model->setProperties(['name' => 'Ada']);
+    }
+}

--- a/tests/Support/Model/MapFromDuplicate.php
+++ b/tests/Support/Model/MapFromDuplicate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\MapFrom;
+
+/**
+ * Stub model with duplicate MapFrom keys used by tests.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class MapFromDuplicate extends AbstractModel
+{
+    #[MapFrom('duplicate-key')]
+    public string $first = '';
+
+    #[MapFrom('duplicate-key')]
+    public string $second = '';
+}

--- a/tests/Support/Model/MapFromPayload.php
+++ b/tests/Support/Model/MapFromPayload.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\MapFrom;
+
+/**
+ * Stub model with explicit input-key mappings used by tests.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class MapFromPayload extends AbstractModel
+{
+    #[MapFrom('@context')]
+    public string $context = '';
+
+    public string $publicEmailPersonal = '';
+
+    #[MapFrom('user-email-address')]
+    public string $userEmailAddress = '';
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
