### PR TITLE
feat(attribute): Added `#[Trim]` to normalize string input before assignment across `load()`, `setProperties()`, and `setPropertyValue()`, including nested-property coverage and mutation-tested edge cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enh #4: Added explicit readonly write protection in `TypeCollector`, replacing fatal reassignment failures with `InvalidArgumentException`, and expanded test coverage for readonly initialization and reassignment paths (@terabytesoftw)
 - Enh #5: Extended automatic type casting to support `DateTime` and `DateTimeImmutable` from string input, added explicit invalid-date errors (including overflow-normalized dates), and expanded coverage for date casting paths (@terabytesoftw)
 - Enh #6: Added `#[MapFrom('key')]` for explicit payload-key mapping in `setProperties()` and `load()`, including support for non-snake_case keys and validation for duplicate mappings (@terabytesoftw)
+- Enh #7: Added `#[Trim]` to normalize string input before assignment across `load()`, `setProperties()`, and `setPropertyValue()`, including nested-property coverage and mutation-tested edge cases (@terabytesoftw)
 
 ## 0.1.0 March 18, 2024
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <p align="center">
     <strong>Typed model mapping for modern PHP applications</strong><br>
-    <em>Nested properties, explicit input mapping, controlled casting, and array serialization</em>
+    <em>Nested properties, explicit input mapping, trim normalization, controlled casting, and array serialization</em>
 </p>
 
 ## Features
@@ -48,10 +48,11 @@ declare(strict_types=1);
 namespace App\Model;
 
 use UIAwesome\Model\AbstractModel;
-use UIAwesome\Model\Attribute\{MapFrom, Timestamp};
+use UIAwesome\Model\Attribute\{MapFrom, Timestamp, Trim};
 
 final class User extends AbstractModel
 {
+    #[Trim]
     public string $name = '';
     #[MapFrom('user-email-address')]
     public string $email = '';
@@ -96,7 +97,33 @@ final class JsonLdPayload extends AbstractModel
 }
 
 $payload = new JsonLdPayload();
+
 $payload->setProperties(['@context' => 'https://schema.org']);
+```
+
+## Automatic input trimming with `Trim`
+
+Use `#[Trim]` to normalize leading and trailing spaces for string values during assignment.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\Trim;
+
+final class Profile extends AbstractModel
+{
+    #[Trim]
+    public string $displayName = '';
+}
+
+$profile = new Profile();
+
+$profile->setProperties(['display_name' => '  Ada Lovelace  ']);
 ```
 
 ## Documentation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,10 +16,11 @@ declare(strict_types=1);
 namespace App\Model;
 
 use UIAwesome\Model\AbstractModel;
-use UIAwesome\Model\Attribute\{DoNotCollect, MapFrom, Timestamp};
+use UIAwesome\Model\Attribute\{DoNotCollect, MapFrom, Timestamp, Trim};
 
 final class User extends AbstractModel
 {
+    #[Trim]
     public string $name = '';
     #[MapFrom('user-email-address')]
     public string $email = '';
@@ -63,6 +64,7 @@ $types = $model->getPropertyTypes();
 - `setPropertyValue()` assigns a single property and supports nested paths (`profile.address.city`).
 - `setProperties()` assigns multiple values and converts snake_case input keys to camelCase.
 - `#[MapFrom('key')]` has priority over snake_case conversion for matching input payload keys.
+- `#[Trim]` trims string values before type casting and assignment.
 - `setProperties($data, $exceptProperties)` exclusions are evaluated in camelCase.
 
 ```php

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,10 +12,11 @@ declare(strict_types=1);
 namespace App\Model;
 
 use UIAwesome\Model\AbstractModel;
-use UIAwesome\Model\Attribute\MapFrom;
+use UIAwesome\Model\Attribute\{MapFrom, Trim};
 
 final class User extends AbstractModel
 {
+    #[Trim]
     public string $name = '';
     #[MapFrom('user-age')]
     public int $age = 0;
@@ -137,6 +138,30 @@ $model = new Post();
 
 $model->setPropertyValue('publishedAt', '2026-03-01T10:00:00+00:00');
 echo $model->getPropertyValue('publishedAt')->format(DATE_ATOM);
+```
+
+## Trim normalization
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\Trim;
+
+final class Profile extends AbstractModel
+{
+    #[Trim]
+    public string $displayName = '';
+}
+
+$model = new Profile();
+$model->setPropertyValue('displayName', '  Ada  ');
+
+echo $model->getPropertyValue('displayName');
 ```
 
 ## Next steps

--- a/docs/svgs/features-mobile.svg
+++ b/docs/svgs/features-mobile.svg
@@ -48,7 +48,7 @@
                 </div>
                 <div class="card">
                     <p class="title"><strong>Attribute Controls</strong></p>
-                    <p class="content"><code>#[MapFrom]</code> maps external payload keys while <code>#[DoNotCollect]</code> and <code>#[Timestamp]</code> control collection and timestamps.</p>
+                    <p class="content"><code>#[MapFrom]</code> maps external payload keys while <code>#[Trim]</code>, <code>#[DoNotCollect]</code>, and <code>#[Timestamp]</code> control normalization and collection.</p>
                 </div>
                 <div class="card">
                     <p class="title"><strong>Model Loading</strong></p>

--- a/docs/svgs/features.svg
+++ b/docs/svgs/features.svg
@@ -46,7 +46,7 @@
                 </div>
                 <div class="card">
                     <p class="title"><strong>Attribute Controls</strong></p>
-                    <p class="content"><code>#[MapFrom]</code> maps external payload keys while <code>#[DoNotCollect]</code> and <code>#[Timestamp]</code> control collection and timestamps.</p>
+                    <p class="content"><code>#[MapFrom]</code> maps external payload keys while <code>#[Trim]</code>, <code>#[DoNotCollect]</code>, and <code>#[Timestamp]</code> control normalization and collection.</p>
                 </div>
                 <div class="card">
                     <p class="title"><strong>Model Loading</strong></p>

--- a/src/Attribute/Trim.php
+++ b/src/Attribute/Trim.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Attribute;
+
+use Attribute;
+
+/**
+ * Trims leading and trailing whitespace from string input before assignment.
+ *
+ * Usage example:
+ * ```php
+ * #[Trim]
+ * public string $name = '';
+ * ```
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Trim {}

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -12,7 +12,7 @@ use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionProperty;
 use ReflectionUnionType;
-use UIAwesome\Model\Attribute\{DoNotCollect, MapFrom, Timestamp};
+use UIAwesome\Model\Attribute\{DoNotCollect, MapFrom, Timestamp, Trim};
 use UIAwesome\Model\Exception\Message;
 
 use function array_filter;
@@ -32,6 +32,7 @@ use function is_scalar;
 use function max;
 use function method_exists;
 use function str_contains;
+use function trim;
 
 /**
  * Collects and manages model property types and values.
@@ -64,11 +65,17 @@ final class TypeCollector
      */
     private ReflectionClass $reflection;
 
+    /**
+     * @phpstan-var array<string, true>
+     */
+    private array $trimProperties = [];
+
     public function __construct(private readonly ModelInterface $model)
     {
         $this->reflection = new ReflectionClass($this->model);
         $this->properties = $this->collectProperties();
         $this->mapFromKeys = $this->collectMapFromKeys();
+        $this->trimProperties = $this->collectTrimProperties();
     }
 
     /**
@@ -466,6 +473,28 @@ final class TypeCollector
     }
 
     /**
+     * Collects properties that should trim string input before assignment.
+     *
+     * @return array<string, true>
+     */
+    private function collectTrimProperties(): array
+    {
+        $keys = [];
+
+        foreach ($this->reflection->getProperties() as $property) {
+            if ($property->isStatic() || $this->hasDoNotCollectAttribute($property)) {
+                continue;
+            }
+
+            if ($property->getAttributes(Trim::class) !== []) {
+                $keys[$property->getName()] = true;
+            }
+        }
+
+        return $keys;
+    }
+
+    /**
      * Checks if the provided type or list of types contains the 'timestamp' type.
      *
      * @param array|string $type Type or list of types to check.
@@ -643,7 +672,8 @@ final class TypeCollector
         $propertyCount = count($properties);
 
         if ($propertyCount === 1) {
-            $valueTypeCast = $this->phpTypeCast($property, $value);
+            $normalizedValue = $this->trimValueIfRequired($property, $value);
+            $valueTypeCast = $this->phpTypeCast($property, $normalizedValue);
             $this->writeProperty($property, $valueTypeCast);
 
             return;
@@ -702,6 +732,18 @@ final class TypeCollector
         }
 
         return [$property, null];
+    }
+
+    /**
+     * Applies trim normalization to string values for properties marked with `Trim`.
+     */
+    private function trimValueIfRequired(string $property, mixed $value): mixed
+    {
+        if (!array_key_exists($property, $this->trimProperties) || !is_string($value)) {
+            return $value;
+        }
+
+        return trim($value);
     }
 
     /**

--- a/tests/Attribute/MapFromTest.php
+++ b/tests/Attribute/MapFromTest.php
@@ -24,7 +24,7 @@ use UIAwesome\Model\Tests\Support\Model\{MapFromDuplicate, MapFromPayload};
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-final class MapFromAttributeTest extends TestCase
+final class MapFromTest extends TestCase
 {
     public function testCollectMappedKeysAfterDoNotCollectPropertyDeclaration(): void
     {

--- a/tests/Attribute/TrimTest.php
+++ b/tests/Attribute/TrimTest.php
@@ -49,6 +49,7 @@ final class TrimTest extends TestCase
             'Should preserve null values and avoid applying trim to non-string inputs.',
         );
     }
+
     public function testLoadTrimsScopedPayloadValues(): void
     {
         $model = new TrimProfile();

--- a/tests/Attribute/TrimTest.php
+++ b/tests/Attribute/TrimTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\DoNotCollect;
+use UIAwesome\Model\Attribute\Trim;
+use UIAwesome\Model\Tests\Support\Model\{TrimAddress, TrimContainer, TrimProfile};
+
+/**
+ * Unit tests for input normalization using {@see \UIAwesome\Model\Attribute\Trim}.
+ *
+ * Test coverage.
+ * - Trims string values during `setPropertyValue()`, `setProperties()`, and `load()`.
+ * - Works with explicit input mapping through `MapFrom`.
+ * - Preserves values for properties without trim metadata.
+ * - Leaves non-string values unchanged.
+ * - Applies trim behavior on nested property writes.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TrimTest extends TestCase
+{
+    public function testDoNotTrimPropertiesWithoutAttribute(): void
+    {
+        $model = new TrimProfile();
+
+        $model->setPropertyValue('rawName', '  Keep Spaces  ');
+
+        self::assertSame(
+            '  Keep Spaces  ',
+            $model->getPropertyValue('rawName'),
+            'Should keep original spacing for properties without Trim.',
+        );
+    }
+
+    public function testKeepNullValueOnNullablePropertyWithoutTrimCastSideEffects(): void
+    {
+        $model = new TrimProfile();
+
+        $model->setPropertyValue('nickname', null);
+
+        self::assertNull(
+            $model->getPropertyValue('nickname'),
+            'Should preserve null values and avoid applying trim to non-string inputs.',
+        );
+    }
+    public function testLoadTrimsScopedPayloadValues(): void
+    {
+        $model = new TrimProfile();
+
+        self::assertTrue(
+            $model->load([
+                'TrimProfile' => [
+                    'name' => '  Ada Lovelace  ',
+                ],
+            ]),
+            'Should report successful load for scoped payloads with trim-enabled properties.',
+        );
+
+        self::assertSame(
+            'Ada Lovelace',
+            $model->getPropertyValue('name'),
+            'Should trim leading and trailing spaces during load().',
+        );
+    }
+
+    public function testSetPropertiesTrimsMappedInputKeys(): void
+    {
+        $model = new TrimProfile();
+
+        $model->setProperties([
+            'display-name' => '  Ada  ',
+        ]);
+
+        self::assertSame(
+            'Ada',
+            $model->getPropertyValue('displayName'),
+            'Should trim mapped values resolved by MapFrom.',
+        );
+    }
+
+    public function testSetPropertyValueTrimsStringInput(): void
+    {
+        $model = new TrimProfile();
+
+        $model->setPropertyValue('name', '  Grace Hopper  ');
+
+        self::assertSame(
+            'Grace Hopper',
+            $model->getPropertyValue('name'),
+            'Should trim string input when assigning a single property.',
+        );
+    }
+
+    public function testTrimAppliesToNestedPropertyAssignments(): void
+    {
+        $model = new TrimContainer(new TrimAddress());
+
+        $model->setPropertyValue('address.city', '  Madrid  ');
+
+        self::assertSame(
+            'Madrid',
+            $model->getPropertyValue('address.city'),
+            'Should trim values when writing nested properties through dot notation.',
+        );
+    }
+
+    public function testTrimCollectionContinuesAfterDoNotCollectProperty(): void
+    {
+        $model = new class extends AbstractModel {
+            #[DoNotCollect]
+            public string $ignored = '';
+
+            #[Trim]
+            public string $name = '';
+        };
+
+        $model->setPropertyValue('name', '  Ada  ');
+
+        self::assertSame(
+            'Ada',
+            $model->getPropertyValue('name'),
+            'Should continue scanning trim metadata after DoNotCollect properties.',
+        );
+    }
+
+    public function testTrimMetadataIgnoresStaticProperties(): void
+    {
+        $model = new class extends AbstractModel {
+            #[Trim]
+            public static string $tag = '';
+
+            public string $name = '';
+        };
+
+        $model->addProperty('tag', 'string');
+        $model->setPropertyValue('tag', '  keep spaces  ');
+
+        self::assertSame(
+            '  keep spaces  ',
+            $model->getPropertyValue('tag'),
+            'Should ignore trim metadata declared on static properties.',
+        );
+    }
+}

--- a/tests/Support/Model/MapFromDuplicate.php
+++ b/tests/Support/Model/MapFromDuplicate.php
@@ -17,7 +17,6 @@ final class MapFromDuplicate extends AbstractModel
 {
     #[MapFrom('duplicate-key')]
     public string $first = '';
-
     #[MapFrom('duplicate-key')]
     public string $second = '';
 }

--- a/tests/Support/Model/MapFromPayload.php
+++ b/tests/Support/Model/MapFromPayload.php
@@ -17,9 +17,7 @@ final class MapFromPayload extends AbstractModel
 {
     #[MapFrom('@context')]
     public string $context = '';
-
     public string $publicEmailPersonal = '';
-
     #[MapFrom('user-email-address')]
     public string $userEmailAddress = '';
 }

--- a/tests/Support/Model/TrimAddress.php
+++ b/tests/Support/Model/TrimAddress.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\Trim;
+
+/**
+ * Stub nested model with trim-enabled properties for tests.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TrimAddress extends AbstractModel
+{
+    #[Trim]
+    public string $city = '';
+}

--- a/tests/Support/Model/TrimContainer.php
+++ b/tests/Support/Model/TrimContainer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use UIAwesome\Model\AbstractModel;
+
+/**
+ * Stub container model for nested trim tests.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TrimContainer extends AbstractModel
+{
+    public function __construct(public readonly TrimAddress $address) {}
+}

--- a/tests/Support/Model/TrimProfile.php
+++ b/tests/Support/Model/TrimProfile.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\MapFrom;
+use UIAwesome\Model\Attribute\Trim;
+
+/**
+ * Stub model with trim-enabled properties for tests.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class TrimProfile extends AbstractModel
+{
+    #[MapFrom('display-name')]
+    #[Trim]
+    public string $displayName = '';
+    #[Trim]
+    public string $name = '';
+    public string|null $nickname = null;
+    public string $rawName = '';
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
