### PR TITLE
feat(model): Added `#[NoSnakeCase]` to preserve selected property names during `toArray(snakeCase: true)` serialization while keeping default conversion for other keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Enh #8: Added `#[Cast]` with built-in `array` casting and pluggable custom caster classes via `CastValueInterface`, with full validation, error reporting, and mutation-tested coverage (@terabytesoftw)
 - Bug #9: Fixed general model stability and consistency issues across core mapping behavior, internal documentation, and test coverage updates (@terabytesoftw)
 - Bug #10: Fixed attribute test-suite organization by moving and isolating core attribute coverage into dedicated test classes for clearer maintenance (@terabytesoftw)
+- Enh #11: Added `#[NoSnakeCase]` to preserve selected property names during `toArray(snakeCase: true)` serialization while keeping default conversion for other keys (@terabytesoftw)
 
 ## 0.1.0 March 18, 2024
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <p align="center">
     <strong>Typed model mapping for modern PHP applications</strong><br>
-    <em>Nested properties, explicit input mapping, trim normalization, custom casting, and array serialization</em>
+    <em>Nested properties, explicit input mapping, trim normalization, custom casting, and selective key serialization</em>
 </p>
 
 ## Features
@@ -48,10 +48,13 @@ declare(strict_types=1);
 namespace App\Model;
 
 use UIAwesome\Model\AbstractModel;
-use UIAwesome\Model\Attribute\{Cast, MapFrom, Timestamp, Trim};
+use UIAwesome\Model\Attribute\{Cast, MapFrom, NoSnakeCase, Timestamp, Trim};
 
 final class User extends AbstractModel
 {
+    #[NoSnakeCase]
+    public string $apiVersion = 'v1';
+
     #[MapFrom('user-email-address')]
     public string $email = '';
 
@@ -70,17 +73,33 @@ $model = new User();
 $model->load(
     [
         'User' => [
+            'apiVersion' => 'v2',
             'name' => '  Ada Lovelace  ',
-            'user-email-address' => 'ada@example.com',
             'tags' => 'php, yii2, model',
+            'user-email-address' => 'ada@example.com',
         ],
     ],
 );
 
 $types = $model->getPropertyTypes();
-// ['name' => 'string', 'email' => 'string', 'tags' => 'array', 'updatedAt' => 'timestamp'];
+/*
+[
+    'apiVersion' => 'string',
+    'name' => 'string',
+    'email' => 'string',
+    'tags' => 'array',
+    'updatedAt' => 'timestamp'
+]
+*/
 $payload = $model->toArray(snakeCase: true, exceptProperties: ['updatedAt']);
-// $payload = ['name' => 'Ada Lovelace', 'email' => 'ada@example.com', 'tags' => ['php', 'yii2', 'model']];
+/*
+[
+    'apiVersion' => 'v2',
+    'name' => 'Ada Lovelace',
+    'email' => 'ada@example.com',
+    'tags' => ['php', 'yii2', 'model']
+]
+*/
 ```
 
 ## Explicit payload mapping with `MapFrom`
@@ -156,6 +175,34 @@ final class SearchFilter extends AbstractModel
 $filter = new SearchFilter();
 
 $filter->setPropertyValue('tags', 'php, yii2, model');
+```
+
+## Preserve selected output keys with `NoSnakeCase`
+
+Use `#[NoSnakeCase]` to keep specific property names unchanged when serializing with `snakeCase: true`.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\NoSnakeCase;
+
+final class ApiPayload extends AbstractModel
+{
+    #[NoSnakeCase]
+    public string $apiVersion = 'v1';
+
+    public string $publicEmailPersonal = 'admin@example.com';
+}
+
+$payload = new ApiPayload();
+
+$data = $payload->toArray(snakeCase: true);
+// ['apiVersion' => 'v1', 'public_email_personal' => 'admin@example.com']
 ```
 
 ## Documentation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,20 +23,20 @@ final class User extends AbstractModel
     #[NoSnakeCase]
     public string $apiVersion = 'v1';
 
-    #[Trim]
-    public string $name = '';
-
     #[MapFrom('user-email-address')]
     public string $email = '';
+
+    #[DoNotCollect]
+    private string $internalToken = '';
+
+    #[Trim]
+    public string $name = '';
 
     #[Trim]
     public string $publicEmailPersonal = '';
 
     #[Cast('array')]
     public array $tags = [];
-
-    #[DoNotCollect]
-    private string $internalToken = '';
 
     #[Timestamp]
     private int $updatedAt = 0;
@@ -68,7 +68,16 @@ $model->load(
 
 ```php
 $types = $model->getPropertyTypes();
-// Example: ['age' => ['int', 'null']]
+/*
+[
+    'apiVersion' => 'string',
+    'email' => 'string',
+    'name' => 'string',
+    'publicEmailPersonal' => 'string',
+    'tags' => 'array',
+    'updatedAt' => 'int',
+]
+*/
 ```
 
 ## Property assignment rules
@@ -103,7 +112,15 @@ $model->setPropertyValue('publishedAt', '2026-03-01T10:00:00+00:00');
 
 ```php
 $payload = $model->toArray(snakeCase: true, exceptProperties: ['updatedAt']);
-// ['apiVersion' => 'v1', 'public_email_personal' => 'dev@example.com']
+/*
+[
+    'apiVersion' => 'v1',
+    'email' => 'dev@example.com',
+    'name' => 'Ada Lovelace',
+    'public_email_personal' => 'dev@example.com',
+    'tags' => [],
+]
+*/
 ```
 
 ## Next steps

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,18 +16,25 @@ declare(strict_types=1);
 namespace App\Model;
 
 use UIAwesome\Model\AbstractModel;
-use UIAwesome\Model\Attribute\{Cast, DoNotCollect, MapFrom, Timestamp, Trim};
+use UIAwesome\Model\Attribute\{Cast, DoNotCollect, MapFrom, NoSnakeCase, Timestamp, Trim};
 
 final class User extends AbstractModel
 {
+    #[NoSnakeCase]
+    public string $apiVersion = 'v1';
+
     #[Trim]
     public string $name = '';
+
     #[MapFrom('user-email-address')]
     public string $email = '';
+
     #[Cast('array')]
     public array $tags = [];
+
     #[DoNotCollect]
     private string $internalToken = '';
+    
     #[Timestamp]
     private int $updatedAt = 0;
 }
@@ -89,9 +96,11 @@ $model->setPropertyValue('publishedAt', '2026-03-01T10:00:00+00:00');
 
 - `toArray(bool $snakeCase = false, array $exceptProperties = [])` exports model data.
 - Use `snakeCase: true` to transform output keys.
+- `#[NoSnakeCase]` preserves marked property names when `snakeCase: true` is enabled.
 
 ```php
 $payload = $model->toArray(snakeCase: true, exceptProperties: ['updatedAt']);
+// ['apiVersion' => 'v1', 'public_email_personal' => 'dev@example.com']
 ```
 
 ## Next steps

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,12 +29,15 @@ final class User extends AbstractModel
     #[MapFrom('user-email-address')]
     public string $email = '';
 
+    #[Trim]
+    public string $publicEmailPersonal = '';
+
     #[Cast('array')]
     public array $tags = [];
 
     #[DoNotCollect]
     private string $internalToken = '';
-    
+
     #[Timestamp]
     private int $updatedAt = 0;
 }

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,12 +12,16 @@ declare(strict_types=1);
 namespace App\Model;
 
 use UIAwesome\Model\AbstractModel;
-use UIAwesome\Model\Attribute\{MapFrom, Trim};
+use UIAwesome\Model\Attribute\{MapFrom, NoSnakeCase, Trim};
 
 final class User extends AbstractModel
 {
+    #[NoSnakeCase]
+    public string $apiVersion = 'v1';
+
     #[Trim]
     public string $name = '';
+
     #[MapFrom('user-age')]
     public int $age = 0;
 }
@@ -29,6 +33,32 @@ echo $model->getPropertyValue('name');
 // "Jane"
 echo $model->getPropertyValue('age');
 // 20
+```
+
+## Preserve selected key casing in serialized output
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\NoSnakeCase;
+
+final class ApiPayload extends AbstractModel
+{
+    #[NoSnakeCase]
+    public string $apiVersion = 'v2';
+
+    public string $publicEmailPersonal = 'admin@example.com';
+}
+
+$model = new ApiPayload();
+
+$data = $model->toArray(snakeCase: true);
+// ['apiVersion' => 'v2', 'public_email_personal' => 'admin@example.com']
 ```
 
 ## Explicit payload-key mapping

--- a/docs/svgs/features-mobile.svg
+++ b/docs/svgs/features-mobile.svg
@@ -1,4 +1,4 @@
-<svg fill="none" viewBox="0 0 600 580" width="100%" height="560" xmlns="http://www.w3.org/2000/svg">
+<svg fill="none" viewBox="0 0 600 600" width="100%" height="560" xmlns="http://www.w3.org/2000/svg">
     <foreignObject width="100%" height="100%">
         <div xmlns="http://www.w3.org/1999/xhtml">
             <style>
@@ -44,11 +44,11 @@
             <div class="container">
                 <div class="card">
                     <p class="title"><strong>Array Serialization</strong></p>
-                    <p class="content">Serialize model state with optional snake_case output and explicit field exclusions.</p>
+                    <p class="content">Serialize model state with optional snake_case output, selective key preservation, and explicit field exclusions.</p>
                 </div>
                 <div class="card">
                     <p class="title"><strong>Attribute Controls</strong></p>
-                    <p class="content"><code>#[MapFrom]</code>, <code>#[Trim]</code>, and <code>#[Cast]</code> control input mapping, normalization, and custom conversion before assignment.</p>
+                    <p class="content"><code>#[MapFrom]</code>, <code>#[Trim]</code>, <code>#[Cast]</code>, and <code>#[NoSnakeCase]</code> control binding, normalization, conversion, and output key behavior.</p>
                 </div>
                 <div class="card">
                     <p class="title"><strong>Model Loading</strong></p>

--- a/docs/svgs/features.svg
+++ b/docs/svgs/features.svg
@@ -42,11 +42,11 @@
             <div class="container">
                 <div class="card">
                     <p class="title"><strong>Array Serialization</strong></p>
-                    <p class="content">Serialize model state with optional snake_case output and explicit field exclusions.</p>
+                    <p class="content">Serialize model state with optional snake_case output, selective key preservation, and explicit field exclusions.</p>
                 </div>
                 <div class="card">
                     <p class="title"><strong>Attribute Controls</strong></p>
-                    <p class="content"><code>#[MapFrom]</code>, <code>#[Trim]</code>, and <code>#[Cast]</code> control input mapping, normalization, and custom conversion before assignment.</p>
+                    <p class="content"><code>#[MapFrom]</code>, <code>#[Trim]</code>, <code>#[Cast]</code>, and <code>#[NoSnakeCase]</code> control binding, normalization, conversion, and output key behavior.</p>
                 </div>
                 <div class="card">
                     <p class="title"><strong>Model Loading</strong></p>

--- a/src/Attribute/NoSnakeCase.php
+++ b/src/Attribute/NoSnakeCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Attribute;
+
+use Attribute;
+
+/**
+ * Prevents key conversion to snake_case during array serialization.
+ *
+ * Usage example:
+ * ```php
+ * #[NoSnakeCase]
+ * public string $apiVersion = '';
+ * ```
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class NoSnakeCase {}

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -72,18 +72,18 @@ final class TypeCollector
     private array $mapFromKeys = [];
 
     /**
-     * Stores collected property type metadata.
-     *
-     * @phpstan-var array<string, list<string>|string>
-     */
-    private array $properties = [];
-
-    /**
      * Marks properties that should preserve their original key during snake_case serialization.
      *
      * @phpstan-var array<string, true>
      */
     private array $noSnakeCaseProperties = [];
+
+    /**
+     * Stores collected property type metadata.
+     *
+     * @phpstan-var array<string, list<string>|string>
+     */
+    private array $properties = [];
 
     /**
      * Reflection handle for the model class.
@@ -568,6 +568,28 @@ final class TypeCollector
     }
 
     /**
+     * Collects properties that should preserve key casing in snake_case serialization.
+     *
+     * @return array<string, true> Property names excluded from snake_case conversion.
+     */
+    private function collectNoSnakeCaseProperties(): array
+    {
+        $keys = [];
+
+        foreach ($this->reflection->getProperties() as $property) {
+            if ($this->hasDoNotCollectAttribute($property)) {
+                continue;
+            }
+
+            if (!$property->isStatic() && $property->getAttributes(NoSnakeCase::class) !== []) {
+                $keys[$property->getName()] = true;
+            }
+        }
+
+        return $keys;
+    }
+
+    /**
      * Returns the list of property types indexed by property names.
      *
      * By default, this method returns all non-static properties of the class.
@@ -616,28 +638,6 @@ final class TypeCollector
         }
 
         return $properties;
-    }
-
-    /**
-     * Collects properties that should preserve key casing in snake_case serialization.
-     *
-     * @return array<string, true> Property names excluded from snake_case conversion.
-     */
-    private function collectNoSnakeCaseProperties(): array
-    {
-        $keys = [];
-
-        foreach ($this->reflection->getProperties() as $property) {
-            if ($this->hasDoNotCollectAttribute($property)) {
-                continue;
-            }
-
-            if (!$property->isStatic() && $property->getAttributes(NoSnakeCase::class) !== []) {
-                $keys[$property->getName()] = true;
-            }
-        }
-
-        return $keys;
     }
 
     /**

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -12,7 +12,7 @@ use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionProperty;
 use ReflectionUnionType;
-use UIAwesome\Model\Attribute\{Cast, DoNotCollect, MapFrom, Timestamp, Trim};
+use UIAwesome\Model\Attribute\{Cast, DoNotCollect, MapFrom, NoSnakeCase, Timestamp, Trim};
 use UIAwesome\Model\Exception\Message;
 
 use function array_filter;
@@ -79,6 +79,13 @@ final class TypeCollector
     private array $properties = [];
 
     /**
+     * Marks properties that should preserve their original key during snake_case serialization.
+     *
+     * @phpstan-var array<string, true>
+     */
+    private array $noSnakeCaseProperties = [];
+
+    /**
      * Reflection handle for the model class.
      *
      * @phpstan-var ReflectionClass<ModelInterface>
@@ -98,6 +105,7 @@ final class TypeCollector
         $this->properties = $this->collectProperties();
         $this->mapFromKeys = $this->collectMapFromKeys();
         $this->castProperties = $this->collectCastProperties();
+        $this->noSnakeCaseProperties = $this->collectNoSnakeCaseProperties();
         $this->trimProperties = $this->collectTrimProperties();
     }
 
@@ -345,7 +353,7 @@ final class TypeCollector
             if (!in_array($property, $exceptProperties, true)) {
                 $value = $this->model->getPropertyValue($property);
 
-                if ($snakeCase) {
+                if ($snakeCase && !array_key_exists($property, $this->noSnakeCaseProperties)) {
                     $property = $this->camelCaseToSnakeCase($property);
                 }
 
@@ -608,6 +616,28 @@ final class TypeCollector
         }
 
         return $properties;
+    }
+
+    /**
+     * Collects properties that should preserve key casing in snake_case serialization.
+     *
+     * @return array<string, true> Property names excluded from snake_case conversion.
+     */
+    private function collectNoSnakeCaseProperties(): array
+    {
+        $keys = [];
+
+        foreach ($this->reflection->getProperties() as $property) {
+            if ($this->hasDoNotCollectAttribute($property)) {
+                continue;
+            }
+
+            if (!$property->isStatic() && $property->getAttributes(NoSnakeCase::class) !== []) {
+                $keys[$property->getName()] = true;
+            }
+        }
+
+        return $keys;
     }
 
     /**

--- a/tests/Attribute/NoSnakeCaseTest.php
+++ b/tests/Attribute/NoSnakeCaseTest.php
@@ -16,10 +16,10 @@ use UIAwesome\Model\Tests\Support\Model\{NoSnakeCaseChild, NoSnakeCasePayload};
  * - Collects and preserves multiple NoSnakeCase properties in the same model.
  * - Continues scanning NoSnakeCase metadata after `DoNotCollect` properties.
  * - Continues scanning NoSnakeCase metadata after static property declarations.
- * - Ignores NoSnakeCase metadata declared on DoNotCollect properties from parent classes.
- * - Keeps default snake_case conversion for non-marked properties.
- * - Preserves marked property names when serializing with `toArray(snakeCase: true)`.
- * - Respects `exceptProperties` while preserving configured keys.
+ * - Has no effect when `snakeCase: false`; original property names remain unchanged.
+ * - Ignores NoSnakeCase metadata declared on parent `DoNotCollect` properties when child properties reuse names.
+ * - Preserves marked property names and keeps snake_case conversion for non-marked properties when `snakeCase: true`.
+ * - Respects `exceptProperties`, including exclusions of NoSnakeCase-marked properties.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -91,6 +91,27 @@ final class NoSnakeCaseTest extends TestCase
             ['api_version' => 'v2'],
             $model->toArray(snakeCase: true),
             'Should ignore NoSnakeCase metadata on parent DoNotCollect properties when child properties share the name.',
+        );
+    }
+
+    public function testNoSnakeCaseHasNoEffectWhenSnakeCaseDisabled(): void
+    {
+        $model = new NoSnakeCasePayload();
+
+        $model->setProperties(
+            [
+                'apiVersion' => 'v1',
+                'publicEmailPersonal' => 'admin@example.com',
+            ],
+        );
+
+        self::assertSame(
+            [
+                'apiVersion' => 'v1',
+                'publicEmailPersonal' => 'admin@example.com',
+            ],
+            $model->toArray(snakeCase: false),
+            'NoSnakeCase should have no effect when snakeCase output is disabled.',
         );
     }
 

--- a/tests/Attribute/NoSnakeCaseTest.php
+++ b/tests/Attribute/NoSnakeCaseTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\{DoNotCollect, NoSnakeCase};
+use UIAwesome\Model\Tests\Support\Model\{NoSnakeCaseChild, NoSnakeCasePayload};
+
+/**
+ * Unit tests for selective key preservation using {@see \UIAwesome\Model\Attribute\NoSnakeCase}.
+ *
+ * Test coverage.
+ * - Collects and preserves multiple NoSnakeCase properties in the same model.
+ * - Continues scanning NoSnakeCase metadata after `DoNotCollect` properties.
+ * - Continues scanning NoSnakeCase metadata after static property declarations.
+ * - Ignores NoSnakeCase metadata declared on DoNotCollect properties from parent classes.
+ * - Keeps default snake_case conversion for non-marked properties.
+ * - Preserves marked property names when serializing with `toArray(snakeCase: true)`.
+ * - Respects `exceptProperties` while preserving configured keys.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class NoSnakeCaseTest extends TestCase
+{
+    public function testPreserveMarkedPropertyNameWhenConvertingToSnakeCaseArray(): void
+    {
+        $model = new NoSnakeCasePayload();
+
+        $model->setProperties(
+            [
+                'apiVersion' => 'v1',
+                'publicEmailPersonal' => 'admin@example.com',
+            ],
+        );
+
+        self::assertSame(
+            [
+                'apiVersion' => 'v1',
+                'public_email_personal' => 'admin@example.com',
+            ],
+            $model->toArray(snakeCase: true),
+            'Should preserve NoSnakeCase property keys while converting non-marked properties to snake_case.',
+        );
+    }
+
+    public function testExcludePreservedPropertyWhenListedInExceptProperties(): void
+    {
+        $model = new NoSnakeCasePayload();
+
+        $model->setProperties(
+            [
+                'apiVersion' => 'v2',
+                'publicEmailPersonal' => 'admin@example.com',
+            ],
+        );
+
+        self::assertSame(
+            ['public_email_personal' => 'admin@example.com'],
+            $model->toArray(snakeCase: true, exceptProperties: ['apiVersion']),
+            'Should still honor exceptProperties for NoSnakeCase-marked properties.',
+        );
+    }
+
+    public function testCollectNoSnakeCaseMetadataAfterDoNotCollectProperty(): void
+    {
+        $model = new class extends AbstractModel {
+            #[DoNotCollect]
+            public string $ignored = '';
+
+            #[NoSnakeCase]
+            public string $apiVersion = '';
+        };
+
+        $model->setPropertyValue('apiVersion', 'v3');
+
+        self::assertSame(
+            ['apiVersion' => 'v3'],
+            $model->toArray(snakeCase: true),
+            'Should continue scanning properties after DoNotCollect entries to gather NoSnakeCase metadata.',
+        );
+    }
+
+    public function testPreserveMultipleNoSnakeCaseProperties(): void
+    {
+        $model = new class extends AbstractModel {
+            #[NoSnakeCase]
+            public string $apiVersion = '';
+
+            #[NoSnakeCase]
+            public string $oauthClientId = '';
+
+            public string $publicEmailPersonal = '';
+        };
+
+        $model->setProperties(
+            [
+                'apiVersion' => 'v1',
+                'oauthClientId' => 'client-01',
+                'publicEmailPersonal' => 'admin@example.com',
+            ],
+        );
+
+        self::assertSame(
+            [
+                'apiVersion' => 'v1',
+                'oauthClientId' => 'client-01',
+                'public_email_personal' => 'admin@example.com',
+            ],
+            $model->toArray(snakeCase: true),
+            'Should preserve all NoSnakeCase-marked keys when multiple mapped properties are present.',
+        );
+    }
+
+    public function testIgnoreParentDoNotCollectNoSnakeCaseMetadataWhenChildReusesPropertyName(): void
+    {
+        $model = new NoSnakeCaseChild();
+
+        $model->setPropertyValue('apiVersion', 'v2');
+
+        self::assertSame(
+            ['api_version' => 'v2'],
+            $model->toArray(snakeCase: true),
+            'Should ignore NoSnakeCase metadata on parent DoNotCollect properties when child properties share the name.',
+        );
+    }
+
+    public function testCollectNoSnakeCaseMetadataAfterStaticPropertyDeclaration(): void
+    {
+        $model = new class extends AbstractModel {
+            public static string $ignored = '';
+
+            #[NoSnakeCase]
+            public string $apiVersion = '';
+        };
+
+        $model->setPropertyValue('apiVersion', 'v4');
+
+        self::assertSame(
+            ['apiVersion' => 'v4'],
+            $model->toArray(snakeCase: true),
+            'Should continue scanning NoSnakeCase metadata after static properties.',
+        );
+    }
+}

--- a/tests/Attribute/NoSnakeCaseTest.php
+++ b/tests/Attribute/NoSnakeCaseTest.php
@@ -26,24 +26,40 @@ use UIAwesome\Model\Tests\Support\Model\{NoSnakeCaseChild, NoSnakeCasePayload};
  */
 final class NoSnakeCaseTest extends TestCase
 {
-    public function testPreserveMarkedPropertyNameWhenConvertingToSnakeCaseArray(): void
+    public function testCollectNoSnakeCaseMetadataAfterDoNotCollectProperty(): void
     {
-        $model = new NoSnakeCasePayload();
+        $model = new class extends AbstractModel {
+            #[DoNotCollect]
+            public string $ignored = '';
 
-        $model->setProperties(
-            [
-                'apiVersion' => 'v1',
-                'publicEmailPersonal' => 'admin@example.com',
-            ],
-        );
+            #[NoSnakeCase]
+            public string $apiVersion = '';
+        };
+
+        $model->setPropertyValue('apiVersion', 'v3');
 
         self::assertSame(
-            [
-                'apiVersion' => 'v1',
-                'public_email_personal' => 'admin@example.com',
-            ],
+            ['apiVersion' => 'v3'],
             $model->toArray(snakeCase: true),
-            'Should preserve NoSnakeCase property keys while converting non-marked properties to snake_case.',
+            'Should continue scanning properties after DoNotCollect entries to gather NoSnakeCase metadata.',
+        );
+    }
+
+    public function testCollectNoSnakeCaseMetadataAfterStaticPropertyDeclaration(): void
+    {
+        $model = new class extends AbstractModel {
+            public static string $ignored = '';
+
+            #[NoSnakeCase]
+            public string $apiVersion = '';
+        };
+
+        $model->setPropertyValue('apiVersion', 'v4');
+
+        self::assertSame(
+            ['apiVersion' => 'v4'],
+            $model->toArray(snakeCase: true),
+            'Should continue scanning NoSnakeCase metadata after static properties.',
         );
     }
 
@@ -65,22 +81,36 @@ final class NoSnakeCaseTest extends TestCase
         );
     }
 
-    public function testCollectNoSnakeCaseMetadataAfterDoNotCollectProperty(): void
+    public function testIgnoreParentDoNotCollectNoSnakeCaseMetadataWhenChildReusesPropertyName(): void
     {
-        $model = new class extends AbstractModel {
-            #[DoNotCollect]
-            public string $ignored = '';
+        $model = new NoSnakeCaseChild();
 
-            #[NoSnakeCase]
-            public string $apiVersion = '';
-        };
-
-        $model->setPropertyValue('apiVersion', 'v3');
+        $model->setPropertyValue('apiVersion', 'v2');
 
         self::assertSame(
-            ['apiVersion' => 'v3'],
+            ['api_version' => 'v2'],
             $model->toArray(snakeCase: true),
-            'Should continue scanning properties after DoNotCollect entries to gather NoSnakeCase metadata.',
+            'Should ignore NoSnakeCase metadata on parent DoNotCollect properties when child properties share the name.',
+        );
+    }
+    public function testPreserveMarkedPropertyNameWhenConvertingToSnakeCaseArray(): void
+    {
+        $model = new NoSnakeCasePayload();
+
+        $model->setProperties(
+            [
+                'apiVersion' => 'v1',
+                'publicEmailPersonal' => 'admin@example.com',
+            ],
+        );
+
+        self::assertSame(
+            [
+                'apiVersion' => 'v1',
+                'public_email_personal' => 'admin@example.com',
+            ],
+            $model->toArray(snakeCase: true),
+            'Should preserve NoSnakeCase property keys while converting non-marked properties to snake_case.',
         );
     }
 
@@ -112,37 +142,6 @@ final class NoSnakeCaseTest extends TestCase
             ],
             $model->toArray(snakeCase: true),
             'Should preserve all NoSnakeCase-marked keys when multiple mapped properties are present.',
-        );
-    }
-
-    public function testIgnoreParentDoNotCollectNoSnakeCaseMetadataWhenChildReusesPropertyName(): void
-    {
-        $model = new NoSnakeCaseChild();
-
-        $model->setPropertyValue('apiVersion', 'v2');
-
-        self::assertSame(
-            ['api_version' => 'v2'],
-            $model->toArray(snakeCase: true),
-            'Should ignore NoSnakeCase metadata on parent DoNotCollect properties when child properties share the name.',
-        );
-    }
-
-    public function testCollectNoSnakeCaseMetadataAfterStaticPropertyDeclaration(): void
-    {
-        $model = new class extends AbstractModel {
-            public static string $ignored = '';
-
-            #[NoSnakeCase]
-            public string $apiVersion = '';
-        };
-
-        $model->setPropertyValue('apiVersion', 'v4');
-
-        self::assertSame(
-            ['apiVersion' => 'v4'],
-            $model->toArray(snakeCase: true),
-            'Should continue scanning NoSnakeCase metadata after static properties.',
         );
     }
 }

--- a/tests/Attribute/NoSnakeCaseTest.php
+++ b/tests/Attribute/NoSnakeCaseTest.php
@@ -93,6 +93,7 @@ final class NoSnakeCaseTest extends TestCase
             'Should ignore NoSnakeCase metadata on parent DoNotCollect properties when child properties share the name.',
         );
     }
+
     public function testPreserveMarkedPropertyNameWhenConvertingToSnakeCaseArray(): void
     {
         $model = new NoSnakeCasePayload();

--- a/tests/Support/Model/NoSnakeCaseChild.php
+++ b/tests/Support/Model/NoSnakeCaseChild.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+/**
+ * Child stub model reusing a parent property name.
+ */
+final class NoSnakeCaseChild extends NoSnakeCaseParent
+{
+    public string $apiVersion = '';
+}

--- a/tests/Support/Model/NoSnakeCaseParent.php
+++ b/tests/Support/Model/NoSnakeCaseParent.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\{DoNotCollect, NoSnakeCase};
+
+/**
+ * Parent stub model combining DoNotCollect and NoSnakeCase metadata.
+ */
+class NoSnakeCaseParent extends AbstractModel
+{
+    #[DoNotCollect]
+    #[NoSnakeCase]
+    private string $apiVersion = '';
+}

--- a/tests/Support/Model/NoSnakeCasePayload.php
+++ b/tests/Support/Model/NoSnakeCasePayload.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\NoSnakeCase;
+
+/**
+ * Stub model containing NoSnakeCase-marked properties.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class NoSnakeCasePayload extends AbstractModel
+{
+    #[NoSnakeCase]
+    public string $apiVersion = '';
+
+    public string $publicEmailPersonal = '';
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
| Fixed issues | <!-- comma-separated list of tickets # fixed by the PR, if any --> |
