### PR TITLE
feat(attribute): Added `#[DefaultValue]` to apply runtime defaults for `null` and empty-string inputs before custom casting and native type conversion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Bug #9: Fixed general model stability and consistency issues across core mapping behavior, internal documentation, and test coverage updates (@terabytesoftw)
 - Bug #10: Fixed attribute test-suite organization by moving and isolating core attribute coverage into dedicated test classes for clearer maintenance (@terabytesoftw)
 - Enh #11: Added `#[NoSnakeCase]` to preserve selected property names during `toArray(snakeCase: true)` serialization while keeping default conversion for other keys (@terabytesoftw)
+- Enh #12: Added `#[DefaultValue]` to apply runtime defaults for `null` and empty-string inputs before custom casting and native type conversion (@terabytesoftw)
 
 ## 0.1.0 March 18, 2024
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <p align="center">
     <strong>Typed model mapping for modern PHP applications</strong><br>
-    <em>Nested properties, explicit input mapping, trim normalization, custom casting, and selective key serialization</em>
+    <em>Nested properties, explicit input mapping, runtime defaults, custom casting, and selective key serialization</em>
 </p>
 
 ## Features
@@ -48,12 +48,15 @@ declare(strict_types=1);
 namespace App\Model;
 
 use UIAwesome\Model\AbstractModel;
-use UIAwesome\Model\Attribute\{Cast, MapFrom, NoSnakeCase, Timestamp, Trim};
+use UIAwesome\Model\Attribute\{Cast, DefaultValue, MapFrom, NoSnakeCase, Timestamp, Trim};
 
 final class User extends AbstractModel
 {
     #[NoSnakeCase]
     public string $apiVersion = 'v1';
+
+    #[DefaultValue('Guest')]
+    public string $displayName = '';
 
     #[MapFrom('user-email-address')]
     public string $email = '';
@@ -74,6 +77,7 @@ $model->load(
     [
         'User' => [
             'apiVersion' => 'v2',
+            'displayName' => '',
             'name' => '  Ada Lovelace  ',
             'tags' => 'php, yii2, model',
             'user-email-address' => 'ada@example.com',
@@ -85,19 +89,21 @@ $types = $model->getPropertyTypes();
 /*
 [
     'apiVersion' => 'string',
+    'displayName' => 'string',
     'name' => 'string',
     'email' => 'string',
     'tags' => 'array',
-    'updatedAt' => 'timestamp'
+    'updatedAt' => 'timestamp',
 ]
 */
 $payload = $model->toArray(snakeCase: true, exceptProperties: ['updatedAt']);
 /*
 [
     'apiVersion' => 'v2',
+    'display_name' => 'Guest',
     'name' => 'Ada Lovelace',
     'email' => 'ada@example.com',
-    'tags' => ['php', 'yii2', 'model']
+    'tags' => ['php', 'yii2', 'model'],
 ]
 */
 ```
@@ -177,6 +183,32 @@ $filter = new SearchFilter();
 $filter->setPropertyValue('tags', 'php, yii2, model');
 ```
 
+## Runtime fallback with `DefaultValue`
+
+Use `#[DefaultValue(...)]` to apply a fallback when input values are `null` or `''`.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\DefaultValue;
+
+final class Profile extends AbstractModel
+{
+    #[DefaultValue('Guest')]
+    public string $displayName = '';
+}
+
+$profile = new Profile();
+
+$profile->setPropertyValue('displayName', '');
+// 'Guest'
+```
+
 ## Preserve selected output keys with `NoSnakeCase`
 
 Use `#[NoSnakeCase]` to keep specific property names unchanged when serializing with `snakeCase: true`.
@@ -202,7 +234,12 @@ final class ApiPayload extends AbstractModel
 $payload = new ApiPayload();
 
 $data = $payload->toArray(snakeCase: true);
-// ['apiVersion' => 'v1', 'public_email_personal' => 'admin@example.com']
+/*
+[
+    'apiVersion' => 'v1',
+    'public_email_personal' => 'admin@example.com',
+]
+*/
 ```
 
 ## Documentation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,12 +16,15 @@ declare(strict_types=1);
 namespace App\Model;
 
 use UIAwesome\Model\AbstractModel;
-use UIAwesome\Model\Attribute\{Cast, DoNotCollect, MapFrom, NoSnakeCase, Timestamp, Trim};
+use UIAwesome\Model\Attribute\{Cast, DefaultValue, DoNotCollect, MapFrom, NoSnakeCase, Timestamp, Trim};
 
 final class User extends AbstractModel
 {
     #[NoSnakeCase]
     public string $apiVersion = 'v1';
+
+    #[DefaultValue('Guest')]
+    public string $displayName = '';
 
     #[MapFrom('user-email-address')]
     public string $email = '';
@@ -71,11 +74,12 @@ $types = $model->getPropertyTypes();
 /*
 [
     'apiVersion' => 'string',
+    'displayName' => 'string',
     'email' => 'string',
     'name' => 'string',
     'publicEmailPersonal' => 'string',
     'tags' => 'array',
-    'updatedAt' => 'int',
+    'updatedAt' => 'timestamp',
 ]
 */
 ```
@@ -86,6 +90,7 @@ $types = $model->getPropertyTypes();
 - `setProperties()` assigns multiple values and converts snake_case input keys to camelCase.
 - `#[MapFrom('key')]` has priority over snake_case conversion for matching input payload keys.
 - `#[Trim]` trims string values before type casting and assignment.
+- `#[DefaultValue(...)]` applies runtime defaults when assigned values are `null` or `''`.
 - `#[Cast('array')]` converts comma-separated strings into arrays before native property casting.
 - `#[Cast(YourCaster::class)]` supports custom casting classes implementing `CastValueInterface`.
 - `setProperties($data, $exceptProperties)` exclusions are evaluated in camelCase.
@@ -93,6 +98,8 @@ $types = $model->getPropertyTypes();
 ```php
 $model->setProperties(['public_email_personal' => 'dev@example.com'], ['publicEmailPersonal']);
 $model->setProperties(['user-email-address' => 'dev@example.com']);
+$model->setPropertyValue('displayName', '');
+// displayName => 'Guest'
 ```
 
 ## Date object casting
@@ -115,6 +122,7 @@ $payload = $model->toArray(snakeCase: true, exceptProperties: ['updatedAt']);
 /*
 [
     'apiVersion' => 'v1',
+    'display_name' => 'Guest',
     'email' => 'dev@example.com',
     'name' => 'Ada Lovelace',
     'public_email_personal' => 'dev@example.com',

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,12 +12,15 @@ declare(strict_types=1);
 namespace App\Model;
 
 use UIAwesome\Model\AbstractModel;
-use UIAwesome\Model\Attribute\{MapFrom, NoSnakeCase, Trim};
+use UIAwesome\Model\Attribute\{DefaultValue, MapFrom, NoSnakeCase, Trim};
 
 final class User extends AbstractModel
 {
     #[NoSnakeCase]
     public string $apiVersion = 'v1';
+
+    #[DefaultValue('Guest')]
+    public string $displayName = '';
 
     #[Trim]
     public string $name = '';
@@ -225,6 +228,31 @@ $model = new SearchFilter();
 $model->setPropertyValue('tags', 'php, yii2, model');
 print_r($model->getPropertyValue('tags'));
 // Array ( [0] => php [1] => yii2 [2] => model )
+```
+
+## Runtime defaults with `DefaultValue`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\DefaultValue;
+
+final class Profile extends AbstractModel
+{
+    #[DefaultValue('Guest')]
+    public string $displayName = '';
+}
+
+$model = new Profile();
+
+$model->setPropertyValue('displayName', '');
+echo $model->getPropertyValue('displayName');
+// "Guest"
 ```
 
 ## Next steps

--- a/docs/svgs/features-mobile.svg
+++ b/docs/svgs/features-mobile.svg
@@ -48,7 +48,7 @@
                 </div>
                 <div class="card">
                     <p class="title"><strong>Attribute Controls</strong></p>
-                    <p class="content"><code>#[MapFrom]</code>, <code>#[Trim]</code>, <code>#[Cast]</code>, and <code>#[NoSnakeCase]</code> control binding, normalization, conversion, and output key behavior.</p>
+                    <p class="content"><code>#[MapFrom]</code>, <code>#[Trim]</code>, <code>#[DefaultValue]</code>, <code>#[Cast]</code>, and <code>#[NoSnakeCase]</code> control binding, normalization, runtime defaults, conversion, and output key behavior.</p>
                 </div>
                 <div class="card">
                     <p class="title"><strong>Model Loading</strong></p>

--- a/docs/svgs/features.svg
+++ b/docs/svgs/features.svg
@@ -1,4 +1,4 @@
-<svg fill="none" viewBox="0 0 1200 410" width="100%" height="340" xmlns="http://www.w3.org/2000/svg">
+<svg fill="none" viewBox="0 0 1200 440" width="100%" height="340" xmlns="http://www.w3.org/2000/svg">
     <foreignObject width="100%" height="100%">
         <div xmlns="http://www.w3.org/1999/xhtml">
             <style>
@@ -46,7 +46,7 @@
                 </div>
                 <div class="card">
                     <p class="title"><strong>Attribute Controls</strong></p>
-                    <p class="content"><code>#[MapFrom]</code>, <code>#[Trim]</code>, <code>#[Cast]</code>, and <code>#[NoSnakeCase]</code> control binding, normalization, conversion, and output key behavior.</p>
+                    <p class="content"><code>#[MapFrom]</code>, <code>#[Trim]</code>, <code>#[DefaultValue]</code>, <code>#[Cast]</code>, and <code>#[NoSnakeCase]</code> control binding, normalization, runtime defaults, conversion, and output key behavior.</p>
                 </div>
                 <div class="card">
                     <p class="title"><strong>Model Loading</strong></p>

--- a/src/Attribute/DefaultValue.php
+++ b/src/Attribute/DefaultValue.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Attribute;
+
+use Attribute;
+
+/**
+ * Applies a runtime default when assigned input is null or an empty string.
+ *
+ * Usage example:
+ * ```php
+ * #[DefaultValue('Guest')]
+ * public string $displayName = '';
+ * ```
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class DefaultValue
+{
+    public function __construct(public readonly mixed $value) {}
+}

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -58,18 +58,18 @@ final class TypeCollector
     private array $castProperties = [];
 
     /**
-     * Stores values assigned to runtime dynamic properties.
-     *
-     * @phpstan-var mixed[]
-     */
-    private array $dynamicValues = [];
-
-    /**
      * Stores runtime default values keyed by model property name.
      *
      * @phpstan-var array<string, mixed>
      */
     private array $defaultValueProperties = [];
+
+    /**
+     * Stores values assigned to runtime dynamic properties.
+     *
+     * @phpstan-var mixed[]
+     */
+    private array $dynamicValues = [];
 
     /**
      * Stores external input-key to property-name mappings.
@@ -370,6 +370,27 @@ final class TypeCollector
         }
 
         return $result;
+    }
+
+    /**
+     * Applies runtime defaults for values assigned as null or empty string.
+     *
+     * @param string $property Property receiving the assigned value.
+     * @param mixed $value Normalized value to inspect.
+     *
+     * @return mixed Default value when applicable; otherwise the original value.
+     */
+    private function applyDefaultValueIfRequired(string $property, mixed $value): mixed
+    {
+        if (!array_key_exists($property, $this->defaultValueProperties)) {
+            return $value;
+        }
+
+        if ($value !== null && $value !== '') {
+            return $value;
+        }
+
+        return $this->defaultValueProperties[$property];
     }
 
     /**
@@ -952,27 +973,6 @@ final class TypeCollector
         }
 
         return [$property, null];
-    }
-
-    /**
-     * Applies runtime defaults for values assigned as null or empty string.
-     *
-     * @param string $property Property receiving the assigned value.
-     * @param mixed $value Normalized value to inspect.
-     *
-     * @return mixed Default value when applicable; otherwise the original value.
-     */
-    private function applyDefaultValueIfRequired(string $property, mixed $value): mixed
-    {
-        if (!array_key_exists($property, $this->defaultValueProperties)) {
-            return $value;
-        }
-
-        if ($value !== null && $value !== '') {
-            return $value;
-        }
-
-        return $this->defaultValueProperties[$property];
     }
 
     /**

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -12,7 +12,7 @@ use ReflectionClass;
 use ReflectionNamedType;
 use ReflectionProperty;
 use ReflectionUnionType;
-use UIAwesome\Model\Attribute\{Cast, DoNotCollect, MapFrom, NoSnakeCase, Timestamp, Trim};
+use UIAwesome\Model\Attribute\{Cast, DefaultValue, DoNotCollect, MapFrom, NoSnakeCase, Timestamp, Trim};
 use UIAwesome\Model\Exception\Message;
 
 use function array_filter;
@@ -65,6 +65,13 @@ final class TypeCollector
     private array $dynamicValues = [];
 
     /**
+     * Stores runtime default values keyed by model property name.
+     *
+     * @phpstan-var array<string, mixed>
+     */
+    private array $defaultValueProperties = [];
+
+    /**
      * Stores external input-key to property-name mappings.
      *
      * @phpstan-var array<string, string>
@@ -105,6 +112,7 @@ final class TypeCollector
         $this->properties = $this->collectProperties();
         $this->mapFromKeys = $this->collectMapFromKeys();
         $this->castProperties = $this->collectCastProperties();
+        $this->defaultValueProperties = $this->collectDefaultValueProperties();
         $this->noSnakeCaseProperties = $this->collectNoSnakeCaseProperties();
         $this->trimProperties = $this->collectTrimProperties();
     }
@@ -506,7 +514,11 @@ final class TypeCollector
         $keys = [];
 
         foreach ($this->reflection->getProperties() as $property) {
-            if ($property->isStatic() || $this->hasDoNotCollectAttribute($property)) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            if ($this->hasDoNotCollectAttribute($property)) {
                 continue;
             }
 
@@ -519,6 +531,38 @@ final class TypeCollector
             /** @phpstan-var Cast $cast */
             $cast = $attributes[0]->newInstance();
             $keys[$property->getName()] = $cast;
+        }
+
+        return $keys;
+    }
+
+    /**
+     * Collects runtime default values for properties marked with `DefaultValue`.
+     *
+     * @return array<string, mixed> Default values indexed by property name.
+     */
+    private function collectDefaultValueProperties(): array
+    {
+        $keys = [];
+
+        foreach ($this->reflection->getProperties() as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            if ($this->hasDoNotCollectAttribute($property)) {
+                continue;
+            }
+
+            $attributes = $property->getAttributes(DefaultValue::class);
+
+            if ($attributes === []) {
+                continue;
+            }
+
+            /** @phpstan-var DefaultValue $defaultValue */
+            $defaultValue = $attributes[0]->newInstance();
+            $keys[$property->getName()] = $defaultValue->value;
         }
 
         return $keys;
@@ -847,7 +891,8 @@ final class TypeCollector
 
         if ($propertyCount === 1) {
             $normalizedValue = $this->trimValueIfRequired($property, $value);
-            $castValue = $this->castValueIfRequired($property, $normalizedValue);
+            $defaultedValue = $this->applyDefaultValueIfRequired($property, $normalizedValue);
+            $castValue = $this->castValueIfRequired($property, $defaultedValue);
             $valueTypeCast = $this->phpTypeCast($property, $castValue);
             $this->writeProperty($property, $valueTypeCast);
 
@@ -907,6 +952,27 @@ final class TypeCollector
         }
 
         return [$property, null];
+    }
+
+    /**
+     * Applies runtime defaults for values assigned as null or empty string.
+     *
+     * @param string $property Property receiving the assigned value.
+     * @param mixed $value Normalized value to inspect.
+     *
+     * @return mixed Default value when applicable; otherwise the original value.
+     */
+    private function applyDefaultValueIfRequired(string $property, mixed $value): mixed
+    {
+        if (!array_key_exists($property, $this->defaultValueProperties)) {
+            return $value;
+        }
+
+        if ($value !== null && $value !== '') {
+            return $value;
+        }
+
+        return $this->defaultValueProperties[$property];
     }
 
     /**

--- a/tests/Attribute/CastTest.php
+++ b/tests/Attribute/CastTest.php
@@ -18,6 +18,7 @@ use UIAwesome\Model\Tests\Support\Model\CastPayload;
  * Test coverage.
  * - Applies cast behavior in `setPropertyValue()`, `setProperties()`, and `load()`.
  * - Casts comma-separated strings to arrays.
+ * - Continues scanning cast metadata after static property declarations.
  * - Supports custom caster classes implementing `CastValueInterface`.
  * - Supports mapped keys and trim normalization before cast execution.
  * - Throws explicit exceptions for invalid cast targets and invalid caster classes.
@@ -136,6 +137,25 @@ final class CastTest extends TestCase
             ['x', 'y'],
             $model->getPropertyValue('tags'),
             'Should continue scanning properties when some do not declare Cast.',
+        );
+    }
+
+    public function testCollectCastMetadataAfterStaticPropertyDeclaration(): void
+    {
+        $model = new class extends AbstractModel {
+            #[Cast('array')]
+            public static string $ignored = '';
+
+            #[Cast('array')]
+            public array $tags = [];
+        };
+
+        $model->setPropertyValue('tags', 'x,y');
+
+        self::assertSame(
+            ['x', 'y'],
+            $model->getPropertyValue('tags'),
+            'Should continue scanning cast metadata after static property declarations.',
         );
     }
 

--- a/tests/Attribute/DefaultValueTest.php
+++ b/tests/Attribute/DefaultValueTest.php
@@ -65,6 +65,7 @@ final class DefaultValueTest extends TestCase
             'Should apply configured default value when assigned input is an empty string.',
         );
     }
+
     public function testApplyDefaultValueWhenInputIsNull(): void
     {
         $model = new DefaultValuePayload();

--- a/tests/Attribute/DefaultValueTest.php
+++ b/tests/Attribute/DefaultValueTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\{DefaultValue, DoNotCollect};
+use UIAwesome\Model\Tests\Support\Model\{DefaultValueChild, DefaultValuePayload};
+
+/**
+ * Unit tests for runtime fallback assignment using {@see \UIAwesome\Model\Attribute\DefaultValue}.
+ *
+ * Test coverage.
+ * - Applies default values when input is `null` or an empty string.
+ * - Applies defaults after trim normalization for whitespace-only strings.
+ * - Applies defaults before custom casting in the assignment pipeline.
+ * - Applies defaults with mapped input keys via `MapFrom`.
+ * - Continues collecting `DefaultValue` metadata after non-decorated or ignored properties.
+ * - Ignores `DefaultValue` metadata declared on `DoNotCollect` and static properties.
+ * - Ignores parent `DoNotCollect` `DefaultValue` metadata when child properties reuse names.
+ * - Keeps explicit non-empty values unchanged.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class DefaultValueTest extends TestCase
+{
+    public function testApplyDefaultValueWhenInputIsNull(): void
+    {
+        $model = new DefaultValuePayload();
+
+        $model->setPropertyValue('displayName', null);
+
+        self::assertSame(
+            'Guest',
+            $model->getPropertyValue('displayName'),
+            'Should apply configured default value when assigned input is null.',
+        );
+    }
+
+    public function testApplyDefaultValueWhenInputIsEmptyString(): void
+    {
+        $model = new DefaultValuePayload();
+
+        $model->setPropertyValue('status', '');
+
+        self::assertSame(
+            'draft',
+            $model->getPropertyValue('status'),
+            'Should apply configured default value when assigned input is an empty string.',
+        );
+    }
+
+    public function testKeepExplicitValueWhenInputIsNotEmpty(): void
+    {
+        $model = new DefaultValuePayload();
+
+        $model->setPropertyValue('displayName', 'Ada');
+
+        self::assertSame(
+            'Ada',
+            $model->getPropertyValue('displayName'),
+            'Should keep explicit non-empty values instead of replacing them with defaults.',
+        );
+    }
+
+    public function testApplyDefaultAfterTrimForWhitespaceOnlyString(): void
+    {
+        $model = new DefaultValuePayload();
+
+        $model->setPropertyValue('bio', '   ');
+
+        self::assertSame(
+            'Unknown',
+            $model->getPropertyValue('bio'),
+            'Should trim whitespace and apply default when the resulting value is empty.',
+        );
+    }
+
+    public function testApplyDefaultWithMappedInputKeyDuringSetProperties(): void
+    {
+        $model = new DefaultValuePayload();
+
+        $model->setProperties(['user-locale' => '']);
+
+        self::assertSame(
+            'en_US',
+            $model->getPropertyValue('locale'),
+            'Should apply defaults after resolving mapped input keys.',
+        );
+    }
+
+    public function testApplyDefaultBeforeCastPipeline(): void
+    {
+        $model = new DefaultValuePayload();
+
+        $model->setPropertyValue('tags', null);
+
+        self::assertSame(
+            ['php', 'model'],
+            $model->getPropertyValue('tags'),
+            'Should apply default string and then cast it to an array using the configured Cast attribute.',
+        );
+    }
+
+    public function testIgnoreDefaultValueMetadataOnDoNotCollectProperty(): void
+    {
+        $model = new class extends AbstractModel {
+            #[DoNotCollect]
+            #[DefaultValue('ignored')]
+            public string $ignored = '';
+
+            #[DefaultValue('kept')]
+            public string $name = '';
+        };
+
+        $model->setPropertyValue('name', null);
+
+        self::assertSame(
+            'kept',
+            $model->getPropertyValue('name'),
+            'Should ignore DefaultValue metadata declared on DoNotCollect properties.',
+        );
+    }
+
+    public function testCollectDefaultValueMetadataAfterStaticPropertyDeclaration(): void
+    {
+        $model = new class extends AbstractModel {
+            #[DefaultValue('ignored-static')]
+            public static string $ignored = '';
+
+            #[DefaultValue('ok')]
+            public string $name = '';
+        };
+
+        $model->setPropertyValue('name', null);
+
+        self::assertSame(
+            'ok',
+            $model->getPropertyValue('name'),
+            'Should continue collecting DefaultValue metadata after static properties.',
+        );
+    }
+
+    public function testCollectDefaultValueMetadataAfterPropertyWithoutAttribute(): void
+    {
+        $model = new class extends AbstractModel {
+            public string $title = '';
+
+            #[DefaultValue('guest')]
+            public string $name = '';
+        };
+
+        $model->setPropertyValue('name', null);
+
+        self::assertSame(
+            'guest',
+            $model->getPropertyValue('name'),
+            'Should continue scanning properties when some entries do not declare DefaultValue.',
+        );
+    }
+
+    public function testIgnoreParentDoNotCollectDefaultValueWhenChildReusesPropertyName(): void
+    {
+        $model = new DefaultValueChild();
+
+        $model->setPropertyValue('status', null);
+
+        self::assertNull(
+            $model->getPropertyValue('status'),
+            'Should ignore parent DoNotCollect DefaultValue metadata for child properties with the same name.',
+        );
+    }
+}

--- a/tests/Attribute/DefaultValueTest.php
+++ b/tests/Attribute/DefaultValueTest.php
@@ -27,16 +27,29 @@ use UIAwesome\Model\Tests\Support\Model\{DefaultValueChild, DefaultValuePayload}
  */
 final class DefaultValueTest extends TestCase
 {
-    public function testApplyDefaultValueWhenInputIsNull(): void
+    public function testApplyDefaultAfterTrimForWhitespaceOnlyString(): void
     {
         $model = new DefaultValuePayload();
 
-        $model->setPropertyValue('displayName', null);
+        $model->setPropertyValue('bio', '   ');
 
         self::assertSame(
-            'Guest',
-            $model->getPropertyValue('displayName'),
-            'Should apply configured default value when assigned input is null.',
+            'Unknown',
+            $model->getPropertyValue('bio'),
+            'Should trim whitespace and apply default when the resulting value is empty.',
+        );
+    }
+
+    public function testApplyDefaultBeforeCastPipeline(): void
+    {
+        $model = new DefaultValuePayload();
+
+        $model->setPropertyValue('tags', null);
+
+        self::assertSame(
+            ['php', 'model'],
+            $model->getPropertyValue('tags'),
+            'Should apply default string and then cast it to an array using the configured Cast attribute.',
         );
     }
 
@@ -52,30 +65,16 @@ final class DefaultValueTest extends TestCase
             'Should apply configured default value when assigned input is an empty string.',
         );
     }
-
-    public function testKeepExplicitValueWhenInputIsNotEmpty(): void
+    public function testApplyDefaultValueWhenInputIsNull(): void
     {
         $model = new DefaultValuePayload();
 
-        $model->setPropertyValue('displayName', 'Ada');
+        $model->setPropertyValue('displayName', null);
 
         self::assertSame(
-            'Ada',
+            'Guest',
             $model->getPropertyValue('displayName'),
-            'Should keep explicit non-empty values instead of replacing them with defaults.',
-        );
-    }
-
-    public function testApplyDefaultAfterTrimForWhitespaceOnlyString(): void
-    {
-        $model = new DefaultValuePayload();
-
-        $model->setPropertyValue('bio', '   ');
-
-        self::assertSame(
-            'Unknown',
-            $model->getPropertyValue('bio'),
-            'Should trim whitespace and apply default when the resulting value is empty.',
+            'Should apply configured default value when assigned input is null.',
         );
     }
 
@@ -92,16 +91,40 @@ final class DefaultValueTest extends TestCase
         );
     }
 
-    public function testApplyDefaultBeforeCastPipeline(): void
+    public function testCollectDefaultValueMetadataAfterPropertyWithoutAttribute(): void
     {
-        $model = new DefaultValuePayload();
+        $model = new class extends AbstractModel {
+            public string $title = '';
 
-        $model->setPropertyValue('tags', null);
+            #[DefaultValue('guest')]
+            public string $name = '';
+        };
+
+        $model->setPropertyValue('name', null);
 
         self::assertSame(
-            ['php', 'model'],
-            $model->getPropertyValue('tags'),
-            'Should apply default string and then cast it to an array using the configured Cast attribute.',
+            'guest',
+            $model->getPropertyValue('name'),
+            'Should continue scanning properties when some entries do not declare DefaultValue.',
+        );
+    }
+
+    public function testCollectDefaultValueMetadataAfterStaticPropertyDeclaration(): void
+    {
+        $model = new class extends AbstractModel {
+            #[DefaultValue('ignored-static')]
+            public static string $ignored = '';
+
+            #[DefaultValue('ok')]
+            public string $name = '';
+        };
+
+        $model->setPropertyValue('name', null);
+
+        self::assertSame(
+            'ok',
+            $model->getPropertyValue('name'),
+            'Should continue collecting DefaultValue metadata after static properties.',
         );
     }
 
@@ -125,43 +148,6 @@ final class DefaultValueTest extends TestCase
         );
     }
 
-    public function testCollectDefaultValueMetadataAfterStaticPropertyDeclaration(): void
-    {
-        $model = new class extends AbstractModel {
-            #[DefaultValue('ignored-static')]
-            public static string $ignored = '';
-
-            #[DefaultValue('ok')]
-            public string $name = '';
-        };
-
-        $model->setPropertyValue('name', null);
-
-        self::assertSame(
-            'ok',
-            $model->getPropertyValue('name'),
-            'Should continue collecting DefaultValue metadata after static properties.',
-        );
-    }
-
-    public function testCollectDefaultValueMetadataAfterPropertyWithoutAttribute(): void
-    {
-        $model = new class extends AbstractModel {
-            public string $title = '';
-
-            #[DefaultValue('guest')]
-            public string $name = '';
-        };
-
-        $model->setPropertyValue('name', null);
-
-        self::assertSame(
-            'guest',
-            $model->getPropertyValue('name'),
-            'Should continue scanning properties when some entries do not declare DefaultValue.',
-        );
-    }
-
     public function testIgnoreParentDoNotCollectDefaultValueWhenChildReusesPropertyName(): void
     {
         $model = new DefaultValueChild();
@@ -171,6 +157,19 @@ final class DefaultValueTest extends TestCase
         self::assertNull(
             $model->getPropertyValue('status'),
             'Should ignore parent DoNotCollect DefaultValue metadata for child properties with the same name.',
+        );
+    }
+
+    public function testKeepExplicitValueWhenInputIsNotEmpty(): void
+    {
+        $model = new DefaultValuePayload();
+
+        $model->setPropertyValue('displayName', 'Ada');
+
+        self::assertSame(
+            'Ada',
+            $model->getPropertyValue('displayName'),
+            'Should keep explicit non-empty values instead of replacing them with defaults.',
         );
     }
 }

--- a/tests/Support/Model/Address.php
+++ b/tests/Support/Model/Address.php
@@ -7,7 +7,7 @@ namespace UIAwesome\Model\Tests\Support\Model;
 use UIAwesome\Model\AbstractModel;
 
 /**
- * Stub nested address model used by test fixtures.
+ * Stub nested address model used for tests.
  *
  * @copyright Copyright (C) 2024 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/Attributes.php
+++ b/tests/Support/Model/Attributes.php
@@ -9,7 +9,7 @@ use UIAwesome\Model\Attribute\DoNotCollect;
 use UIAwesome\Model\Attribute\Timestamp;
 
 /**
- * Stub model with attribute-driven properties used by test fixtures.
+ * Stub model with attribute-driven properties used for tests.
  *
  * @copyright Copyright (C) 2024 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/Country.php
+++ b/tests/Support/Model/Country.php
@@ -7,7 +7,7 @@ namespace UIAwesome\Model\Tests\Support\Model;
 use UIAwesome\Model\AbstractModel;
 
 /**
- * Stub country model used by test fixtures.
+ * Stub country model used for tests.
  *
  * @copyright Copyright (C) 2024 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/DefaultValueChild.php
+++ b/tests/Support/Model/DefaultValueChild.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace UIAwesome\Model\Tests\Support\Model;
 
-use UIAwesome\Model\AbstractModel;
-
 /**
- * Stub container model for nested trim for tests.
+ * Stub child model reusing a parent property name for tests.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-final class TrimContainer extends AbstractModel
+final class DefaultValueChild extends DefaultValueParent
 {
-    public function __construct(public readonly TrimAddress $address) {}
+    public string|null $status = '';
 }

--- a/tests/Support/Model/DefaultValueParent.php
+++ b/tests/Support/Model/DefaultValueParent.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\{DefaultValue, DoNotCollect};
+
+/**
+ * Stub parent model combining `DoNotCollect` and `DefaultValue` metadata for tests.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+class DefaultValueParent extends AbstractModel
+{
+    #[DoNotCollect]
+    #[DefaultValue('parent-default')]
+    private string $status = '';
+}

--- a/tests/Support/Model/DefaultValuePayload.php
+++ b/tests/Support/Model/DefaultValuePayload.php
@@ -15,12 +15,16 @@ use UIAwesome\Model\Attribute\{Cast, DefaultValue, DoNotCollect, MapFrom, Trim};
  */
 final class DefaultValuePayload extends AbstractModel
 {
-    #[DefaultValue('Guest')]
-    public string $displayName = '';
-
     #[Trim]
     #[DefaultValue('Unknown')]
     public string $bio = '';
+
+    #[DefaultValue('Guest')]
+    public string $displayName = '';
+
+    #[DoNotCollect]
+    #[DefaultValue('ignored')]
+    public string $internal = '';
 
     #[MapFrom('user-locale')]
     #[DefaultValue('en_US')]
@@ -32,8 +36,4 @@ final class DefaultValuePayload extends AbstractModel
     #[Cast('array')]
     #[DefaultValue('php,model')]
     public array $tags = [];
-
-    #[DoNotCollect]
-    #[DefaultValue('ignored')]
-    public string $internal = '';
 }

--- a/tests/Support/Model/DefaultValuePayload.php
+++ b/tests/Support/Model/DefaultValuePayload.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Attribute\{Cast, DefaultValue, DoNotCollect, MapFrom, Trim};
+
+/**
+ * Stub model with DefaultValue-driven properties for tests.
+ *
+ * @copyright Copyright (C) 2026 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class DefaultValuePayload extends AbstractModel
+{
+    #[DefaultValue('Guest')]
+    public string $displayName = '';
+
+    #[Trim]
+    #[DefaultValue('Unknown')]
+    public string $bio = '';
+
+    #[MapFrom('user-locale')]
+    #[DefaultValue('en_US')]
+    public string $locale = '';
+
+    #[DefaultValue('draft')]
+    public string|null $status = null;
+
+    #[Cast('array')]
+    #[DefaultValue('php,model')]
+    public array $tags = [];
+
+    #[DoNotCollect]
+    #[DefaultValue('ignored')]
+    public string $internal = '';
+}

--- a/tests/Support/Model/Dynamic.php
+++ b/tests/Support/Model/Dynamic.php
@@ -7,7 +7,7 @@ namespace UIAwesome\Model\Tests\Support\Model;
 use UIAwesome\Model\AbstractModel;
 
 /**
- * Stub dynamic model used by test fixtures.
+ * Stub dynamic model used for tests.
  *
  * @copyright Copyright (C) 2024 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/DynamicNested.php
+++ b/tests/Support/Model/DynamicNested.php
@@ -7,7 +7,7 @@ namespace UIAwesome\Model\Tests\Support\Model;
 use UIAwesome\Model\AbstractModel;
 
 /**
- * Stub nested dynamic model used by test fixtures.
+ * Stub nested dynamic model used for tests.
  *
  * @copyright Copyright (C) 2024 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/MapFromDuplicate.php
+++ b/tests/Support/Model/MapFromDuplicate.php
@@ -8,7 +8,7 @@ use UIAwesome\Model\AbstractModel;
 use UIAwesome\Model\Attribute\MapFrom;
 
 /**
- * Stub model with duplicate MapFrom keys used by tests.
+ * Stub model with duplicate MapFrom keys used for tests.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/MapFromPayload.php
+++ b/tests/Support/Model/MapFromPayload.php
@@ -8,7 +8,7 @@ use UIAwesome\Model\AbstractModel;
 use UIAwesome\Model\Attribute\MapFrom;
 
 /**
- * Stub model with explicit input-key mappings used by tests.
+ * Stub model with explicit input-key mappings used for tests.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/NoSnakeCaseChild.php
+++ b/tests/Support/Model/NoSnakeCaseChild.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace UIAwesome\Model\Tests\Support\Model;
 
 /**
- * Child stub model reusing a parent property name.
+ * Child stub model reusing a parent property name for tests.
  */
 final class NoSnakeCaseChild extends NoSnakeCaseParent
 {

--- a/tests/Support/Model/NoSnakeCaseParent.php
+++ b/tests/Support/Model/NoSnakeCaseParent.php
@@ -8,7 +8,7 @@ use UIAwesome\Model\AbstractModel;
 use UIAwesome\Model\Attribute\{DoNotCollect, NoSnakeCase};
 
 /**
- * Parent stub model combining DoNotCollect and NoSnakeCase metadata.
+ * Parent stub model combining DoNotCollect and NoSnakeCase metadata for tests.
  */
 class NoSnakeCaseParent extends AbstractModel
 {

--- a/tests/Support/Model/NoSnakeCasePayload.php
+++ b/tests/Support/Model/NoSnakeCasePayload.php
@@ -8,7 +8,7 @@ use UIAwesome\Model\AbstractModel;
 use UIAwesome\Model\Attribute\NoSnakeCase;
 
 /**
- * Stub model containing NoSnakeCase-marked properties.
+ * Stub model containing NoSnakeCase-marked properties used for tests.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/NonNamespaced.php
+++ b/tests/Support/Model/NonNamespaced.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use UIAwesome\Model\AbstractModel;
 
 /**
- * Stub non-namespaced model used by test fixtures.
+ * Stub non-namespaced model used for tests.
  *
  * @copyright Copyright (C) 2024 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/Profile.php
+++ b/tests/Support/Model/Profile.php
@@ -8,7 +8,7 @@ use UIAwesome\Model\AbstractModel;
 use UIAwesome\Model\Attribute\DoNotCollect;
 
 /**
- * Stub profile model with nested address relation used by test fixtures.
+ * Stub profile model with nested address relation used for tests.
  *
  * @copyright Copyright (C) 2024 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/ReadonlyState.php
+++ b/tests/Support/Model/ReadonlyState.php
@@ -7,7 +7,7 @@ namespace UIAwesome\Model\Tests\Support\Model;
 use UIAwesome\Model\AbstractModel;
 
 /**
- * Stub model exposing readonly properties for assignment for tests.
+ * Stub model exposing readonly properties for assignment tests.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/ReadonlyState.php
+++ b/tests/Support/Model/ReadonlyState.php
@@ -7,7 +7,7 @@ namespace UIAwesome\Model\Tests\Support\Model;
 use UIAwesome\Model\AbstractModel;
 
 /**
- * Stub model exposing readonly properties for assignment tests.
+ * Stub model exposing readonly properties for assignment for tests.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/TrimContainer.php
+++ b/tests/Support/Model/TrimContainer.php
@@ -7,7 +7,7 @@ namespace UIAwesome\Model\Tests\Support\Model;
 use UIAwesome\Model\AbstractModel;
 
 /**
- * Stub container model for nested trim for tests.
+ * Stub container model for nested trim tests.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/UnionType.php
+++ b/tests/Support/Model/UnionType.php
@@ -7,7 +7,7 @@ namespace UIAwesome\Model\Tests\Support\Model;
 use UIAwesome\Model\AbstractModel;
 
 /**
- * Stub model with union-typed property used by test fixtures.
+ * Stub model with union-typed property used for tests.
  *
  * @copyright Copyright (C) 2024 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.

--- a/tests/Support/Model/User.php
+++ b/tests/Support/Model/User.php
@@ -7,7 +7,7 @@ namespace UIAwesome\Model\Tests\Support\Model;
 use UIAwesome\Model\AbstractModel;
 
 /**
- * Stub user model with nested profile relation used by test fixtures.
+ * Stub user model with nested profile relation used for tests.
  *
  * @copyright Copyright (C) 2024 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
