### PR TITLE
fix(model): Simplified `TypeCollector` internals by streamlining `DoNotCollect` detection, normalizing static-property checks, reducing dead fallback logic in nested-property split handling, and using first-class callable trimming while preserving behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bug #10: Fixed attribute test-suite organization by moving and isolating core attribute coverage into dedicated test classes for clearer maintenance (@terabytesoftw)
 - Enh #11: Added `#[NoSnakeCase]` to preserve selected property names during `toArray(snakeCase: true)` serialization while keeping default conversion for other keys (@terabytesoftw)
 - Enh #12: Added `#[DefaultValue]` to apply runtime defaults for `null` and empty-string inputs before custom casting and native type conversion (@terabytesoftw)
+- Bug #13: Simplified `TypeCollector` internals by streamlining `DoNotCollect` detection, normalizing static-property checks, reducing dead fallback logic in nested-property split handling, and using first-class callable trimming while preserving behavior (@terabytesoftw)
 
 ## 0.1.0 March 18, 2024
 

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -511,7 +511,7 @@ final class TypeCollector
         }
 
         $items = array_map(
-            static fn(string $item): string => trim($item),
+            trim(...),
             explode($separator, $value),
         );
 
@@ -668,7 +668,7 @@ final class TypeCollector
         $properties = [];
 
         foreach ($this->reflection->getProperties() as $property) {
-            if ($property->isStatic() === false && !$this->hasDoNotCollectAttribute($property)) {
+            if (!$property->isStatic() && !$this->hasDoNotCollectAttribute($property)) {
                 /** @phpstan-var ReflectionNamedType|ReflectionUnionType|null $type */
                 $type = $property->getType();
 
@@ -764,13 +764,7 @@ final class TypeCollector
      */
     private function hasDoNotCollectAttribute(ReflectionProperty $property): bool
     {
-        foreach ($property->getAttributes() as $attribute) {
-            if ($attribute->getName() === DoNotCollect::class) {
-                return true;
-            }
-        }
-
-        return false;
+        return $property->getAttributes(DoNotCollect::class) !== [];
     }
 
     /**
@@ -967,9 +961,10 @@ final class TypeCollector
     private function splitProperty(string $property): array
     {
         if (str_contains($property, '.')) {
+            /** @phpstan-var array{0: string, 1: string} $result */
             $result = explode('.', $property, 2);
 
-            return [$result[0], $result[1] ?? null];
+            return [$result[0], $result[1]];
         }
 
         return [$property, null];


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
