### PR TITLE
fix(model): Consolidated `TypeCollector` metadata collection into a single reflection pass, removing repeated collector loops while preserving map-key validation and attribute-driven behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Enh #12: Added `#[DefaultValue]` to apply runtime defaults for `null` and empty-string inputs before custom casting and native type conversion (@terabytesoftw)
 - Bug #13: Simplified `TypeCollector` internals by streamlining `DoNotCollect` detection, normalizing static-property checks, reducing dead fallback logic in nested-property split handling, and using first-class callable trimming while preserving behavior (@terabytesoftw)
 - Bug #14: Simplified `AbstractModel::load()` by replacing a boolean `match` expression with an equivalent ternary assignment for clearer payload scope resolution while preserving behavior (@terabytesoftw)
+- Bug #15: Consolidated `TypeCollector` metadata collection into a single reflection pass, removing repeated collector loops while preserving map-key validation and attribute-driven behavior (@terabytesoftw)
 
 ## 0.1.0 March 18, 2024
 

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -109,12 +109,7 @@ final class TypeCollector
     public function __construct(private readonly ModelInterface $model)
     {
         $this->reflection = new ReflectionClass($this->model);
-        $this->properties = $this->collectProperties();
-        $this->mapFromKeys = $this->collectMapFromKeys();
-        $this->castProperties = $this->collectCastProperties();
-        $this->defaultValueProperties = $this->collectDefaultValueProperties();
-        $this->noSnakeCaseProperties = $this->collectNoSnakeCaseProperties();
-        $this->trimProperties = $this->collectTrimProperties();
+        $this->collectMetadata();
     }
 
     /**
@@ -524,87 +519,64 @@ final class TypeCollector
     }
 
     /**
-     * Collects cast configuration for properties marked with `Cast`.
-     *
-     * @return array Cast configuration indexed by property name.
-     *
-     * @phpstan-return array<string, Cast>
-     */
-    private function collectCastProperties(): array
-    {
-        $keys = [];
-
-        foreach ($this->reflection->getProperties() as $property) {
-            if ($property->isStatic()) {
-                continue;
-            }
-
-            if ($this->hasDoNotCollectAttribute($property)) {
-                continue;
-            }
-
-            $attributes = $property->getAttributes(Cast::class);
-
-            if ($attributes === []) {
-                continue;
-            }
-
-            /** @phpstan-var Cast $cast */
-            $cast = $attributes[0]->newInstance();
-            $keys[$property->getName()] = $cast;
-        }
-
-        return $keys;
-    }
-
-    /**
-     * Collects runtime default values for properties marked with `DefaultValue`.
-     *
-     * @return array<string, mixed> Default values indexed by property name.
-     */
-    private function collectDefaultValueProperties(): array
-    {
-        $keys = [];
-
-        foreach ($this->reflection->getProperties() as $property) {
-            if ($property->isStatic()) {
-                continue;
-            }
-
-            if ($this->hasDoNotCollectAttribute($property)) {
-                continue;
-            }
-
-            $attributes = $property->getAttributes(DefaultValue::class);
-
-            if ($attributes === []) {
-                continue;
-            }
-
-            /** @phpstan-var DefaultValue $defaultValue */
-            $defaultValue = $attributes[0]->newInstance();
-            $keys[$property->getName()] = $defaultValue->value;
-        }
-
-        return $keys;
-    }
-
-    /**
-     * Collects explicit input-key mappings from `MapFrom` property attributes.
+     * Collects all property metadata in a single reflection pass.
      *
      * @throws InvalidArgumentException if duplicate input keys are found in `MapFrom` attributes.
-     *
-     * @return array Input keys indexed to property names.
-     *
-     * @phpstan-return array<string, string>
      */
-    private function collectMapFromKeys(): array
+    private function collectMetadata(): void
     {
-        $keys = [];
-
         foreach ($this->reflection->getProperties() as $property) {
             if ($property->isStatic() || $this->hasDoNotCollectAttribute($property)) {
                 continue;
+            }
+
+            $propertyName = $property->getName();
+
+            /** @phpstan-var ReflectionNamedType|ReflectionUnionType|null $type */
+            $type = $property->getType();
+
+            if ($type !== null) {
+                if ($type instanceof ReflectionUnionType) {
+                    $typeNames = [];
+
+                    foreach ($type->getTypes() as $unionType) {
+                        if ($unionType instanceof ReflectionNamedType) {
+                            $typeNames[] = $unionType->getName();
+                        }
+                    }
+
+                    $this->properties[$propertyName] = $typeNames;
+                } else {
+                    $typeName = $type->getName();
+
+                    if ($type->allowsNull() && $typeName !== 'null') {
+                        $this->properties[$propertyName] = [$typeName, 'null'];
+                    } else {
+                        $this->properties[$propertyName] = $typeName;
+                    }
+                }
+            } else {
+                $this->properties[$propertyName] = '';
+            }
+
+            if ($property->getAttributes(Timestamp::class) !== []) {
+                $this->properties[$propertyName] = 'timestamp';
+            }
+
+            $castAttributes = $property->getAttributes(Cast::class);
+
+            if ($castAttributes !== []) {
+                /** @phpstan-var Cast $cast */
+                $cast = $castAttributes[0]->newInstance();
+                $this->castProperties[$propertyName] = $cast;
+            }
+
+            $defaultValueAttributes = $property->getAttributes(DefaultValue::class);
+
+            if ($defaultValueAttributes !== []) {
+                /** @phpstan-var DefaultValue $defaultValue */
+                $defaultValue = $defaultValueAttributes[0]->newInstance();
+                $this->defaultValueProperties[$propertyName] = $defaultValue->value;
             }
 
             foreach ($property->getAttributes(MapFrom::class) as $attribute) {
@@ -613,120 +585,29 @@ final class TypeCollector
 
                 $key = $mapFrom->key;
 
-                if (array_key_exists($key, $keys) && $keys[$key] !== $property->getName()) {
+                if (array_key_exists($key, $this->mapFromKeys) && $this->mapFromKeys[$key] !== $propertyName) {
                     throw new InvalidArgumentException(
                         Message::DUPLICATE_MAP_FROM_KEY->getMessage(
                             $key,
                             $this->model::class,
-                            $keys[$key],
+                            $this->mapFromKeys[$key],
                             $this->model::class,
-                            $property->getName(),
+                            $propertyName,
                         ),
                     );
                 }
 
-                $keys[$key] = $property->getName();
-            }
-        }
-
-        return $keys;
-    }
-
-    /**
-     * Collects properties that should preserve key casing in snake_case serialization.
-     *
-     * @return array<string, true> Property names excluded from snake_case conversion.
-     */
-    private function collectNoSnakeCaseProperties(): array
-    {
-        $keys = [];
-
-        foreach ($this->reflection->getProperties() as $property) {
-            if ($this->hasDoNotCollectAttribute($property)) {
-                continue;
+                $this->mapFromKeys[$key] = $propertyName;
             }
 
-            if (!$property->isStatic() && $property->getAttributes(NoSnakeCase::class) !== []) {
-                $keys[$property->getName()] = true;
-            }
-        }
-
-        return $keys;
-    }
-
-    /**
-     * Returns the list of property types indexed by property names.
-     *
-     * By default, this method returns all non-static properties of the class.
-     *
-     * @return array List of property types indexed by property names.
-     *
-     * @phpstan-return array<string, list<string>|string>
-     */
-    private function collectProperties(): array
-    {
-        $properties = [];
-
-        foreach ($this->reflection->getProperties() as $property) {
-            if (!$property->isStatic() && !$this->hasDoNotCollectAttribute($property)) {
-                /** @phpstan-var ReflectionNamedType|ReflectionUnionType|null $type */
-                $type = $property->getType();
-
-                if ($type !== null) {
-                    if ($type instanceof ReflectionUnionType) {
-                        $typeNames = [];
-
-                        foreach ($type->getTypes() as $unionType) {
-                            if ($unionType instanceof ReflectionNamedType) {
-                                $typeNames[] = $unionType->getName();
-                            }
-                        }
-
-                        $properties[$property->getName()] = $typeNames;
-                    } else {
-                        $typeName = $type->getName();
-
-                        if ($type->allowsNull() && $typeName !== 'null') {
-                            $properties[$property->getName()] = [$typeName, 'null'];
-                        } else {
-                            $properties[$property->getName()] = $typeName;
-                        }
-                    }
-                } else {
-                    $properties[$property->getName()] = '';
-                }
-
-                if ($property->getAttributes(Timestamp::class) !== []) {
-                    $properties[$property->getName()] = 'timestamp';
-                }
-            }
-        }
-
-        return $properties;
-    }
-
-    /**
-     * Collects properties that should trim string input before assignment.
-     *
-     * @return array Property names that require trim normalization.
-     *
-     * @phpstan-return array<string, true>
-     */
-    private function collectTrimProperties(): array
-    {
-        $keys = [];
-
-        foreach ($this->reflection->getProperties() as $property) {
-            if ($property->isStatic() || $this->hasDoNotCollectAttribute($property)) {
-                continue;
+            if ($property->getAttributes(NoSnakeCase::class) !== []) {
+                $this->noSnakeCaseProperties[$propertyName] = true;
             }
 
             if ($property->getAttributes(Trim::class) !== []) {
-                $keys[$property->getName()] = true;
+                $this->trimProperties[$propertyName] = true;
             }
         }
-
-        return $keys;
     }
 
     /**

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -531,33 +531,7 @@ final class TypeCollector
             }
 
             $propertyName = $property->getName();
-
-            /** @phpstan-var ReflectionNamedType|ReflectionUnionType|null $type */
-            $type = $property->getType();
-
-            if ($type !== null) {
-                if ($type instanceof ReflectionUnionType) {
-                    $typeNames = [];
-
-                    foreach ($type->getTypes() as $unionType) {
-                        if ($unionType instanceof ReflectionNamedType) {
-                            $typeNames[] = $unionType->getName();
-                        }
-                    }
-
-                    $this->properties[$propertyName] = $typeNames;
-                } else {
-                    $typeName = $type->getName();
-
-                    if ($type->allowsNull() && $typeName !== 'null') {
-                        $this->properties[$propertyName] = [$typeName, 'null'];
-                    } else {
-                        $this->properties[$propertyName] = $typeName;
-                    }
-                }
-            } else {
-                $this->properties[$propertyName] = '';
-            }
+            $this->properties[$propertyName] = $this->resolvePropertyType($property);
 
             if ($property->getAttributes(Timestamp::class) !== []) {
                 $this->properties[$propertyName] = 'timestamp';
@@ -733,6 +707,41 @@ final class TypeCollector
         }
 
         return $this->snakeCaseToCamelCase($property);
+    }
+
+    /**
+     * Resolves property type metadata from reflection.
+     *
+     * @phpstan-return list<string>|string
+     */
+    private function resolvePropertyType(ReflectionProperty $property): array|string
+    {
+        /** @phpstan-var ReflectionNamedType|ReflectionUnionType|null $type */
+        $type = $property->getType();
+
+        if ($type === null) {
+            return '';
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            $typeNames = [];
+
+            foreach ($type->getTypes() as $unionType) {
+                if ($unionType instanceof ReflectionNamedType) {
+                    $typeNames[] = $unionType->getName();
+                }
+            }
+
+            return $typeNames;
+        }
+
+        $typeName = $type->getName();
+
+        if ($type->allowsNull() && $typeName !== 'null') {
+            return [$typeName, 'null'];
+        }
+
+        return $typeName;
     }
 
     /**

--- a/src/TypeCollector.php
+++ b/src/TypeCollector.php
@@ -9,6 +9,7 @@ use DateTimeImmutable;
 use Exception;
 use InvalidArgumentException;
 use ReflectionClass;
+use ReflectionIntersectionType;
 use ReflectionNamedType;
 use ReflectionProperty;
 use ReflectionUnionType;
@@ -716,11 +717,23 @@ final class TypeCollector
      */
     private function resolvePropertyType(ReflectionProperty $property): array|string
     {
-        /** @phpstan-var ReflectionNamedType|ReflectionUnionType|null $type */
+        /** @phpstan-var ReflectionIntersectionType|ReflectionNamedType|ReflectionUnionType|null $type */
         $type = $property->getType();
 
         if ($type === null) {
             return '';
+        }
+
+        if ($type instanceof ReflectionIntersectionType) {
+            $typeNames = [];
+
+            foreach ($type->getTypes() as $intersectionType) {
+                if ($intersectionType instanceof ReflectionNamedType) {
+                    $typeNames[] = $intersectionType->getName();
+                }
+            }
+
+            return $typeNames;
         }
 
         if ($type instanceof ReflectionUnionType) {

--- a/tests/Support/Contract/IntersectionLeft.php
+++ b/tests/Support/Contract/IntersectionLeft.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Contract;
+
+/**
+ * Left interface marker for intersection type tests.
+ *
+ * @copyright Copyright (C) 2024 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+interface IntersectionLeft {}

--- a/tests/Support/Contract/IntersectionRight.php
+++ b/tests/Support/Contract/IntersectionRight.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Contract;
+
+/**
+ * Right interface marker for intersection type tests.
+ *
+ * @copyright Copyright (C) 2024 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+interface IntersectionRight {}

--- a/tests/Support/Model/IntersectionType.php
+++ b/tests/Support/Model/IntersectionType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use UIAwesome\Model\AbstractModel;
+use UIAwesome\Model\Tests\Support\Contract\{IntersectionLeft, IntersectionRight};
+
+/**
+ * Stub model with intersection-typed property used for tests.
+ *
+ * @copyright Copyright (C) 2024 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class IntersectionType extends AbstractModel
+{
+    private IntersectionLeft&IntersectionRight $intersection;
+}

--- a/tests/TypeCollectorTest.php
+++ b/tests/TypeCollectorTest.php
@@ -12,7 +12,8 @@ use PHPUnit\Framework\TestCase;
 use TypeError;
 use UIAwesome\Model\Exception\Message;
 use UIAwesome\Model\Tests\Provider\TypeCollectorProvider;
-use UIAwesome\Model\Tests\Support\Model\{Address, Country, DateTimeType, PropertyType, ReadonlyState};
+use UIAwesome\Model\Tests\Support\Contract\{IntersectionLeft, IntersectionRight};
+use UIAwesome\Model\Tests\Support\Model\{Address, Country, DateTimeType, IntersectionType, PropertyType, ReadonlyState};
 use UIAwesome\Model\TypeCollector;
 
 /**
@@ -21,6 +22,7 @@ use UIAwesome\Model\TypeCollector;
  * Test coverage.
  * - Casts values to declared PHP property types, including stringable objects and nullable typed properties.
  * - Detects property presence for flat and nested property paths.
+ * - Resolves intersection-typed properties into the expected named type metadata.
  * - Returns null for type casting requests targeting unknown properties.
  * - Returns property names and type metadata collected from model declarations.
  * - Throws type errors when assigned values violate declared property types.
@@ -189,6 +191,19 @@ final class TypeCollectorTest extends TestCase
             $dateTime,
             $model->getPropertyValue('createdAt'),
             'Should keep existing DateTime object instances without rebuilding them.',
+        );
+    }
+
+    public function testReturnCollectedIntersectionPropertyType(): void
+    {
+        $model = new IntersectionType();
+
+        self::assertSame(
+            [
+                'intersection' => [IntersectionLeft::class, IntersectionRight::class],
+            ],
+            $model->getPropertyTypes(),
+            'Should collect all named members from intersection-typed properties.',
         );
     }
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
