### PR TITLE
fix(tests): Added dedicated regression coverage to ensure `TypeCollector::toArray()` preserves custom `getPropertyValue()` override behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Bug #14: Simplified `AbstractModel::load()` by replacing a boolean `match` expression with an equivalent ternary assignment for clearer payload scope resolution while preserving behavior (@terabytesoftw)
 - Bug #15: Consolidated `TypeCollector` metadata collection into a single reflection pass, removing repeated collector loops while preserving map-key validation and attribute-driven behavior (@terabytesoftw)
 - Bug #16: Refactored `snakeCaseToCamelCase` method for improved readability and performance by consolidating logic into a single return statement (@terabytesoftw)
+- Bug #17: Added dedicated regression coverage to ensure `TypeCollector::toArray()` preserves custom `getPropertyValue()` override behavior (@terabytesoftw)
 
 ## 0.1.0 March 18, 2024
 

--- a/tests/Support/Model/GetPropertyValueOverride.php
+++ b/tests/Support/Model/GetPropertyValueOverride.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace UIAwesome\Model\Tests\Support\Model;
+
+use UIAwesome\Model\AbstractModel;
+
+use function is_string;
+
+/**
+ * Stub model overriding getPropertyValue to validate toArray behavior.
+ *
+ * @copyright Copyright (C) 2024 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class GetPropertyValueOverride extends AbstractModel
+{
+    public string $name = 'ada';
+
+    public function getPropertyValue(string $property): mixed
+    {
+        $value = parent::getPropertyValue($property);
+
+        return is_string($value) ? $value . '-override' : $value;
+    }
+}

--- a/tests/TypeCollectorTest.php
+++ b/tests/TypeCollectorTest.php
@@ -13,7 +13,7 @@ use TypeError;
 use UIAwesome\Model\Exception\Message;
 use UIAwesome\Model\Tests\Provider\TypeCollectorProvider;
 use UIAwesome\Model\Tests\Support\Contract\{IntersectionLeft, IntersectionRight};
-use UIAwesome\Model\Tests\Support\Model\{Address, Country, DateTimeType, IntersectionType, PropertyType, ReadonlyState};
+use UIAwesome\Model\Tests\Support\Model\{Address, Country, DateTimeType, GetPropertyValueOverride, IntersectionType, PropertyType, ReadonlyState};
 use UIAwesome\Model\TypeCollector;
 
 /**
@@ -22,6 +22,7 @@ use UIAwesome\Model\TypeCollector;
  * Test coverage.
  * - Casts values to declared PHP property types, including stringable objects and nullable typed properties.
  * - Detects property presence for flat and nested property paths.
+ * - Keeps `toArray()` aligned with custom `getPropertyValue()` overrides.
  * - Resolves intersection-typed properties into the expected named type metadata.
  * - Returns null for type casting requests targeting unknown properties.
  * - Returns property names and type metadata collected from model declarations.
@@ -351,6 +352,17 @@ final class TypeCollectorTest extends TestCase
             'joe',
             $model->toArray(true)['name'],
             'Should keep the assigned value for converted snake_case keys.',
+        );
+    }
+
+    public function testReturnToArrayUsingCustomGetPropertyValueOverride(): void
+    {
+        $model = new GetPropertyValueOverride();
+
+        self::assertSame(
+            ['name' => 'ada-override'],
+            $model->toArray(),
+            'Should preserve custom getPropertyValue behavior when exporting model to array.',
         );
     }
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
